### PR TITLE
Added 3.7 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 
 install:
   - pip install codecov
@@ -15,7 +16,6 @@ install:
 
 script:
   - coverage run setup.py test
-
 
 after_success:
   codecov

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     description="Checkout.com Python SDK",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    zip_safe=False,
     url="https://github.com/checkout/checkout-sdk-python",
     license='MIT',
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Tests will now cover Python 3.4/3.5/3.6/3.7