### PR TITLE
Alternative Payment Integration

### DIFF
--- a/checkout_sdk/payments/__init__.py
+++ b/checkout_sdk/payments/__init__.py
@@ -1,7 +1,9 @@
-from checkout_sdk.payments.payment_response import PaymentResponse
-from checkout_sdk.payments.payment_action_response import PaymentActionResponse
+from checkout_sdk.payments.payment_response import PaymentResponse, AlternativePaymentResponse
+from checkout_sdk.payments.payment_action_response import (
+    PaymentActionResponse, AlternativePaymentActionResponse
+)
 from checkout_sdk.payments.payment_history import PaymentHistory
-from checkout_sdk.payments.payment_processed import PaymentProcessed
+from checkout_sdk.payments.payment_processed import PaymentProcessed, AlternativePaymentProcessed
 from checkout_sdk.payments.threeds_response import ThreeDSResponse
 from checkout_sdk.payments.capture_response import CaptureResponse
 from checkout_sdk.payments.void_response import VoidResponse

--- a/checkout_sdk/payments/payment_action_response.py
+++ b/checkout_sdk/payments/payment_action_response.py
@@ -1,4 +1,4 @@
-from checkout_sdk.payments import PaymentResponse
+from checkout_sdk.payments import PaymentResponse, AlternativePaymentResponse
 
 
 class PaymentActionResponse(PaymentResponse):
@@ -18,6 +18,16 @@ class PaymentActionResponse(PaymentResponse):
     def value(self):
         return self._response.body['value']
 
+    @property
+    def response_code(self):
+        return self._response.body['responseCode']
+
+    @property
+    def approved(self):
+        return str(self.response_code).startswith('1')
+
+
+class AlternativePaymentActionResponse(AlternativePaymentResponse):
     @property
     def response_code(self):
         return self._response.body['responseCode']

--- a/checkout_sdk/payments/payment_processed.py
+++ b/checkout_sdk/payments/payment_processed.py
@@ -1,4 +1,4 @@
-from checkout_sdk.payments import PaymentActionResponse
+from checkout_sdk.payments import PaymentActionResponse, AlternativePaymentActionResponse
 from checkout_sdk.common import Customer, Card
 
 
@@ -25,3 +25,16 @@ class PaymentProcessed(PaymentActionResponse):
     @property
     def customer(self):
         return self._customer
+
+
+class AlternativePaymentProcessed(AlternativePaymentActionResponse):
+    def __int__(self, api_response):
+        super().__init__(api_response)
+
+    @property
+    def charge_mode(self):
+        return self._response.body['chargeMode']
+
+    @property
+    def live_mode(self):
+        return self._response.body['liveMode']

--- a/checkout_sdk/payments/payment_response.py
+++ b/checkout_sdk/payments/payment_response.py
@@ -11,3 +11,9 @@ class PaymentResponse(ApiResponse):
     @property
     def requires_redirect(self):
         return Utils.verify_redirect_flow(self._response)
+
+
+class AlternativePaymentResponse(PaymentResponse):
+    @property
+    def requires_redirect(self):
+        return Utils.verify_alternative_payment_redirect_flow(self._response)

--- a/checkout_sdk/payments/payments_client.py
+++ b/checkout_sdk/payments/payments_client.py
@@ -4,6 +4,7 @@ from checkout_sdk import ApiClient, Utils, HttpMethod
 from checkout_sdk.payments import (
     PaymentHistory,
     PaymentProcessed,
+    AlternativePaymentProcessed,
     ThreeDSResponse,
     CaptureResponse,
     VoidResponse,
@@ -78,6 +79,28 @@ class PaymentsClient(ApiClient):
             return ThreeDSResponse(http_response)
         else:
             return PaymentProcessed(http_response)
+
+    def alternative_payment_request(self,
+                                    payment_provider_id, payment_token,
+                                    issuer_id=None, customer=None, *kwargs):
+        request = {
+            'localPayment': {
+                'lppId': payment_provider_id,
+                'userData': {}
+            },
+            'paymentToken': payment_token
+        }
+
+        if issuer_id is not None:
+            request['localPayment']['userData']['issuerId'] = issuer_id
+
+        if Utils.is_email(customer):
+            request['email'] = customer
+
+        request.update(kwargs)
+
+        http_response = self._send_http_request('charges/localpayment', HttpMethod.POST, request)
+        return AlternativePaymentProcessed(http_response)
 
     def capture(self, id, value=None, track_id=None, **kwargs):
         return CaptureResponse(self._getPaymentActionResponse(id, 'capture', value, track_id, **kwargs))

--- a/checkout_sdk/payments/payments_client.py
+++ b/checkout_sdk/payments/payments_client.py
@@ -80,6 +80,11 @@ class PaymentsClient(ApiClient):
         else:
             return PaymentProcessed(http_response)
 
+    def alternative_payment_info(self):
+        alt_info_url = 'lookups/localpayments/lpp_9/tags/issuerid'
+        http_response = self._send_http_request(alt_info_url, HttpMethod.GET)
+        return http_response.body
+
     def alternative_payment_request(self,
                                     payment_provider_id, payment_token,
                                     issuer_id=None, customer=None, *kwargs):

--- a/checkout_sdk/utils.py
+++ b/checkout_sdk/utils.py
@@ -76,3 +76,9 @@ class Utils:
         # this is how a 3D response is detected currently
         return http_response.body.get('redirectUrl') is not None \
             and PAYMENT_TOKEN_REGEX.match(http_response.body.get('id')) is not None
+
+    @classmethod
+    def verify_alternative_payment_redirect_flow(cls, http_response):
+        return http_response.body.get('localPayment', {}).get('paymentUrl', None) is not None \
+            and PAYMENT_TOKEN_REGEX.match((http_response.body.get('id'))) is not None
+

--- a/tests/test_payments_client.py
+++ b/tests/test_payments_client.py
@@ -191,11 +191,10 @@ class PaymentsClientTests(CheckoutSdkTestCase):
 
     def test_alternative_payment_request(self):
         token = self.token_client.request_payment_token(
-            value=100, currency=sdk.Currency.USD
+            value=100, currency=sdk.Currency.EUR
         )
         payment = self.alternative_payment(
-            payment_token=token.id, payment_provider='lpp_19'  # Currently checks with PayPal
-            # provider
+            payment_token=token.id, payment_provider='lpp_9', issuer_id='INGBNL2A'
         )
 
         self.assertTrue(payment.approved)

--- a/tests/test_payments_client.py
+++ b/tests/test_payments_client.py
@@ -194,7 +194,8 @@ class PaymentsClientTests(CheckoutSdkTestCase):
             value=100, currency=sdk.Currency.USD
         )
         payment = self.alternative_payment(
-            payment_token=token, payment_provider='lpp_19'  # Currently checks with PayPal provider
+            payment_token=token.id, payment_provider='lpp_19'  # Currently checks with PayPal
+            # provider
         )
 
         self.assertTrue(payment.approved)

--- a/tests/test_payments_client.py
+++ b/tests/test_payments_client.py
@@ -189,6 +189,18 @@ class PaymentsClientTests(CheckoutSdkTestCase):
         self.assertTrue(response2.approved)
         self.assertEqual(response2.value, 80)
 
+    def test_alternative_payment_information(self):
+        info = self.client.alternative_payment_info()
+
+        self.assertTrue(isinstance(info, dict))
+        lookup_details = info.get('lookupDetails', None)
+        self.assertIsNotNone(lookup_details)
+        self.assertTrue(isinstance(lookup_details, list))
+
+        if len(lookup_details) > 0:
+            self.assertIsNotNone(lookup_details[0].get('tagName', None))
+            self.assertIsNotNone(lookup_details[0].get('values', None))
+
     def test_alternative_payment_request(self):
         token = self.token_client.request_payment_token(
             value=100, currency=sdk.Currency.EUR


### PR DESCRIPTION
- Adds the following methods:

     - `alternative_payment_info`: Fetches the alternative payment issuers list.
     - `alternative_payment_request`: Handles the alternative payment request (follows existing guideliness)

- Adds tests for the aforementioned methods.