### PR TITLE
Improve SDK responses and exception handling

### DIFF
--- a/checkout_sdk/environment.py
+++ b/checkout_sdk/environment.py
@@ -12,13 +12,13 @@ class Environment:
     @staticmethod
     def sandbox():
         return Environment(base_uri='https://api.sandbox.checkout.com/',
-                           authorization_uri="https://access.sandbox.checkout.com/connect/token",
+                           authorization_uri='https://access.sandbox.checkout.com/connect/token',
                            files_uri='https://files.sandbox.checkout.com/',
                            is_sandbox=True)
 
     @staticmethod
     def production():
         return Environment(base_uri='https://api.checkout.com/',
-                           authorization_uri="https://access.checkout.com/connect/token",
+                           authorization_uri='https://access.checkout.com/connect/token',
                            files_uri='https://files.checkout.com/',
                            is_sandbox=False)

--- a/checkout_sdk/exception.py
+++ b/checkout_sdk/exception.py
@@ -29,12 +29,16 @@ class CheckoutAuthorizationException(CheckoutException):
 
 
 class CheckoutApiException(CheckoutException):
-    request_id: str
     http_status_code: int
+    http_response: dict
+    request_id: str
     error_details: dict
 
-    def __init__(self, request_id: str = None, http_status_code: int = None, error_details: dict = None):
-        self.request_id = request_id
-        self.http_status_code = http_status_code
-        self.error_details = error_details
-        super().__init__('The API response status code ({}) does not indicate success.'.format(http_status_code))
+    def __init__(self, response):
+        self.http_status_code = response.status_code
+        self.http_response = response
+        if response.text:
+            payload = response.json()
+            self.request_id = payload['request_id'] if 'request_id' in payload else None
+            self.error_details = payload['error_codes'] if 'error_codes' in payload else None
+        super().__init__('The API response status code ({}) does not indicate success.'.format(response.status_code))

--- a/checkout_sdk/four/oauth_credentials.py
+++ b/checkout_sdk/four/oauth_credentials.py
@@ -77,7 +77,7 @@ class FourOAuthSdkCredentials(SdkCredentials, metaclass=ABCMeta):
             response.raise_for_status()
         except HTTPError as err:
             errors = json.loads(err.response.text)
-            message = 'OAuth client_credentials authentication failed with error: ({})'.format(errors["error"])
+            message = 'OAuth client_credentials authentication failed with error: ({})'.format(errors['error'])
             raise CheckoutAuthorizationException(message)
         except ConnectionError:
             raise CheckoutAuthorizationException(

--- a/checkout_sdk/four/oauth_sdk.py
+++ b/checkout_sdk/four/oauth_sdk.py
@@ -9,9 +9,9 @@ from checkout_sdk.four.oauth_credentials import FourOAuthSdkCredentials
 
 
 class OAuthSdk(CheckoutSdkBuilder, metaclass=ABCMeta):
-    _client_id: str = ""
-    _client_secret: str = ""
-    _authorization_uri: str = ""
+    _client_id: str = ''
+    _client_secret: str = ''
+    _authorization_uri: str = ''
     _scopes: list = []
 
     def __init__(self):

--- a/checkout_sdk/sdk_authorization.py
+++ b/checkout_sdk/sdk_authorization.py
@@ -17,4 +17,4 @@ class SdkAuthorization:
         if PlatformType.FOUR == self.platform_type or \
                 PlatformType.FOUR_OAUTH == self.platform_type:
             return 'Bearer ' + self.credential
-        raise CheckoutAuthorizationException("Invalid platform type")
+        raise CheckoutAuthorizationException('Invalid platform type')

--- a/checkout_sdk/tokens/tokens_client.py
+++ b/checkout_sdk/tokens/tokens_client.py
@@ -8,7 +8,7 @@ from checkout_sdk.tokens.tokens import WalletTokenRequest, CardTokenRequest
 
 
 class TokensClient(Client):
-    __TOKENS = "tokens"
+    __TOKENS = 'tokens'
 
     def __init__(self, api_client: ApiClient, configuration: CheckoutConfiguration):
         super().__init__(api_client=api_client,

--- a/tests/apm/ideal_four_integration_test.py
+++ b/tests/apm/ideal_four_integration_test.py
@@ -6,6 +6,7 @@ from tests.checkout_test_utils import assert_response
 def test_should_get_info(four_api):
     response = four_api.ideal.get_info()
     assert_response(response,
+                    'http_response',
                     '_links',
                     '_links.self',
                     '_links.ideal:issuers',
@@ -15,6 +16,7 @@ def test_should_get_info(four_api):
 def test_should_get_issuers(four_api):
     response = four_api.ideal.get_issuers()
     assert_response(response,
+                    'http_response',
                     'countries',
                     '_links',
                     '_links.self')

--- a/tests/apm/ideal_integration_test.py
+++ b/tests/apm/ideal_integration_test.py
@@ -6,6 +6,7 @@ from tests.checkout_test_utils import assert_response
 def test_should_get_info(default_api):
     response = default_api.ideal.get_info()
     assert_response(response,
+                    'http_response',
                     '_links',
                     '_links.self',
                     '_links.ideal:issuers',
@@ -15,6 +16,7 @@ def test_should_get_info(default_api):
 def test_should_get_issuers(default_api):
     response = default_api.ideal.get_issuers()
     assert_response(response,
+                    'http_response',
                     'countries',
                     '_links',
                     '_links.self')

--- a/tests/apm/klarna_integration_test.py
+++ b/tests/apm/klarna_integration_test.py
@@ -24,12 +24,14 @@ def test_should_create_and_get_klarna_session(default_api):
 
     create_response = default_api.klarna.create_credit_session(credit_session_request)
     assert_response(create_response,
+                    'http_response',
                     'session_id',
                     'client_token',
                     'payment_method_categories')
 
     create_response = default_api.klarna.get_credit_session(create_response['session_id'])
     assert_response(create_response,
+                    'http_response',
                     'client_token',
                     'purchase_country',
                     'currency',

--- a/tests/customers/customers_four_integration_test.py
+++ b/tests/customers/customers_four_integration_test.py
@@ -12,6 +12,7 @@ def test_should_create_and_get_customer(four_api):
     customer_id = create_customer(four_api, email)
     response = four_api.customers.get(customer_id)
     assert_response(response,
+                    'http_response',
                     'email',
                     'name',
                     'phone')
@@ -29,6 +30,7 @@ def test_should_create_and_update_customer(four_api):
 
     response_update = four_api.customers.get(customer_id)
     assert_response(response_update,
+                    'http_response',
                     'email',
                     'name',
                     'phone')
@@ -44,7 +46,7 @@ def test_should_create_and_delete_customer(four_api):
         four_api.customers.get(customer_id)
         pytest.fail()
     except CheckoutApiException as err:
-        assert err.args[0] == "The API response status code (404) does not indicate success."
+        assert err.args[0] == 'The API response status code (404) does not indicate success.'
 
 
 def create_customer(four_api, email):

--- a/tests/customers/customers_integration_test.py
+++ b/tests/customers/customers_integration_test.py
@@ -12,6 +12,7 @@ def test_should_create_and_get_customer(default_api):
     customer_id = create_customer(default_api, email)
     response = default_api.customers.get(customer_id)
     assert_response(response,
+                    'http_response',
                     'email',
                     'name',
                     'phone')
@@ -29,6 +30,7 @@ def test_should_create_and_update_customer(default_api):
 
     response_update = default_api.customers.get(customer_id)
     assert_response(response_update,
+                    'http_response',
                     'email',
                     'name',
                     'phone')
@@ -44,7 +46,7 @@ def test_should_create_and_delete_customer(default_api):
         default_api.customers.get(customer_id)
         pytest.fail()
     except CheckoutApiException as err:
-        assert err.args[0] == "The API response status code (404) does not indicate success."
+        assert err.args[0] == 'The API response status code (404) does not indicate success.'
 
 
 def create_customer(default_api, email):

--- a/tests/disputes/disputes_four_integration_test.py
+++ b/tests/disputes/disputes_four_integration_test.py
@@ -20,6 +20,7 @@ def test_should_query_disputes(four_api):
 
     response = four_api.disputes.query(query)
     assert_response(response,
+                    'http_response',
                     'limit',
                     'total_count',
                     'from',
@@ -44,6 +45,7 @@ def test_should_upload_file(four_api):
 
     file_details = four_api.disputes.get_file_details(response['id'])
     assert_response(file_details,
+                    'http_response',
                     'id',
                     'filename',
                     'purpose',
@@ -88,6 +90,7 @@ def test_should_test_full_disputes_workflow(four_api):
 
     evidence = four_api.disputes.get_evidence(dispute_id)
     assert_response(evidence,
+                    'http_response',
                     'proof_of_delivery_or_service_file',
                     'proof_of_delivery_or_service_text',
                     'invoice_or_receipt_file',

--- a/tests/disputes/disputes_integration_test.py
+++ b/tests/disputes/disputes_integration_test.py
@@ -20,6 +20,7 @@ def test_should_query_disputes(default_api):
 
     response = default_api.disputes.query(query)
     assert_response(response,
+                    'http_response',
                     'limit',
                     'total_count',
                     'from',
@@ -44,6 +45,7 @@ def test_should_upload_file(default_api):
 
     file_details = default_api.disputes.get_file_details(response['id'])
     assert_response(file_details,
+                    'http_response',
                     'id',
                     'filename',
                     'purpose',
@@ -88,6 +90,7 @@ def test_should_test_full_disputes_workflow(default_api):
 
     evidence = default_api.disputes.get_evidence(dispute_id)
     assert_response(evidence,
+                    'http_response',
                     'proof_of_delivery_or_service_file',
                     'proof_of_delivery_or_service_text',
                     'invoice_or_receipt_file',

--- a/tests/forex/forex_four_integration_test.py
+++ b/tests/forex/forex_four_integration_test.py
@@ -14,6 +14,7 @@ def test_should_request_quote(oauth_api):
 
     response = oauth_api.forex.request_quote(quote_request)
     assert_response(response,
+                    'http_response',
                     'id',
                     'source_currency',
                     'source_amount',

--- a/tests/instruments/instruments_four_integration_test.py
+++ b/tests/instruments/instruments_four_integration_test.py
@@ -16,6 +16,7 @@ from tests.checkout_test_utils import assert_response, phone, VisaCard, address,
 def test_should_create_and_get_instrument(four_api):
     create_instrument_response = create_token_instrument(four_api)
     assert_response(create_instrument_response,
+                    'http_response',
                     'bin',
                     'card_category',
                     'card_type',
@@ -36,6 +37,7 @@ def test_should_create_and_get_instrument(four_api):
     get_instrument_response = four_api.instruments.get(create_instrument_response['id'])
 
     assert_response(get_instrument_response,
+                    'http_response',
                     'bin',
                     'card_category',
                     'card_type',
@@ -84,6 +86,7 @@ def test_should_create_and_update_instrument(four_api):
     assert get_instrument_response['expiry_month'] == 12
 
     assert_response(create_instrument_response,
+                    'http_response',
                     'scheme',
                     'bin',
                     'card_category',

--- a/tests/instruments/instruments_integration_test.py
+++ b/tests/instruments/instruments_integration_test.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 import pytest
 
 from checkout_sdk.exception import CheckoutApiException
-from checkout_sdk.instruments.instruments import CreateInstrumentRequest, InstrumentCustomerRequest, UpdateInstrumentRequest
+from checkout_sdk.instruments.instruments import CreateInstrumentRequest, InstrumentCustomerRequest, \
+    UpdateInstrumentRequest
 from checkout_sdk.tokens.tokens import CardTokenRequest
 from tests.checkout_test_utils import assert_response, phone, VisaCard, address, NAME
 
@@ -11,69 +12,71 @@ from tests.checkout_test_utils import assert_response, phone, VisaCard, address,
 def test_should_create_and_get_instrument(default_api):
     create_instrument_response = create_token_instrument(default_api)
     assert_response(create_instrument_response,
-                    "bin",
-                    "card_category",
-                    "card_type",
-                    "customer",
-                    "customer.email",
-                    "customer.name",
-                    "expiry_month",
-                    "expiry_year",
-                    "fingerprint",
-                    "id",
-                    # "issuer",
-                    "issuer_country",
-                    "last4",
-                    "product_id",
-                    "product_type",
-                    "type")
+                    'http_response',
+                    'bin',
+                    'card_category',
+                    'card_type',
+                    'customer',
+                    'customer.email',
+                    'customer.name',
+                    'expiry_month',
+                    'expiry_year',
+                    'fingerprint',
+                    'id',
+                    # 'issuer',
+                    'issuer_country',
+                    'last4',
+                    'product_id',
+                    'product_type',
+                    'type')
 
-    get_instrument_response = default_api.instruments.get(create_instrument_response["id"])
+    get_instrument_response = default_api.instruments.get(create_instrument_response['id'])
 
     assert_response(get_instrument_response,
-                    "bin",
-                    "card_category",
-                    "card_type",
-                    "customer",
-                    "customer.email",
-                    "customer.name",
-                    "expiry_month",
-                    "expiry_year",
-                    "fingerprint",
-                    "id",
-                    # "issuer",
-                    "issuer_country",
-                    "last4",
-                    "product_id",
-                    "product_type",
-                    "type")
+                    'http_response',
+                    'bin',
+                    'card_category',
+                    'card_type',
+                    'customer',
+                    'customer.email',
+                    'customer.name',
+                    'expiry_month',
+                    'expiry_year',
+                    'fingerprint',
+                    'id',
+                    # 'issuer',
+                    'issuer_country',
+                    'last4',
+                    'product_id',
+                    'product_type',
+                    'type')
 
 
 def test_should_create_and_update_instrument(default_api):
     create_instrument_response = create_token_instrument(default_api)
 
     update_instrument_request = UpdateInstrumentRequest()
-    update_instrument_request.name = "new name"
+    update_instrument_request.name = 'new name'
     update_instrument_request.expiry_year = 2026
     update_instrument_request.expiry_month = 12
 
-    default_api.instruments.update(create_instrument_response["id"], update_instrument_request)
+    default_api.instruments.update(create_instrument_response['id'], update_instrument_request)
 
-    get_instrument_response = default_api.instruments.get(create_instrument_response["id"])
+    get_instrument_response = default_api.instruments.get(create_instrument_response['id'])
 
     assert get_instrument_response is not None
-    assert get_instrument_response["name"] == "new name"
-    assert get_instrument_response["expiry_year"] == 2026
-    assert get_instrument_response["expiry_month"] == 12
+    assert get_instrument_response['name'] == 'new name'
+    assert get_instrument_response['expiry_year'] == 2026
+    assert get_instrument_response['expiry_month'] == 12
 
 
 def test_should_create_and_delete_instrument(default_api):
     create_instrument_response = create_token_instrument(default_api)
 
-    default_api.instruments.delete(create_instrument_response["id"])
+    default_api.instruments.delete(create_instrument_response['id'])
 
     with pytest.raises(CheckoutApiException):
-        default_api.instruments.get(create_instrument_response["id"])
+        default_api.instruments.get(create_instrument_response['id'])
 
 
 def create_token_instrument(default_api):
@@ -87,19 +90,19 @@ def create_token_instrument(default_api):
     card_token_request.phone = phone()
 
     card_token_response = default_api.tokens.request_card_token(card_token_request)
-    assert_response(card_token_response, "token")
+    assert_response(card_token_response, 'token')
 
     customer = InstrumentCustomerRequest
-    customer.email = "brucewayne@gmail.com"
+    customer.email = 'brucewayne@gmail.com'
     customer.name = NAME
     customer.default = True
     customer.phone = phone()
 
     create_instrument_request = CreateInstrumentRequest()
-    create_instrument_request.token = card_token_response["token"]
+    create_instrument_request.token = card_token_response['token']
     create_instrument_request.customer = customer
 
     create_instrument_response = default_api.instruments.create(create_instrument_request)
-    assert_response(card_token_response, "token")
+    assert_response(card_token_response, 'token')
 
     return create_instrument_response

--- a/tests/payments/four/capture_payments_four_integration_test.py
+++ b/tests/payments/four/capture_payments_four_integration_test.py
@@ -15,6 +15,7 @@ def test_should_full_capture_card_payment(four_api):
                                  payment_id=payment_response['id'],
                                  capture_request=capture_request)
     assert_response(capture_response,
+                    'http_response',
                     'reference',
                     'action_id',
                     '_links')
@@ -31,6 +32,7 @@ def test_should_partially_capture_card_payment(four_api):
                                  payment_id=payment_response['id'],
                                  capture_request=capture_request)
     assert_response(capture_response,
+                    'http_response',
                     'reference',
                     'action_id',
                     '_links')

--- a/tests/payments/four/get_payment_details_four_integration_test.py
+++ b/tests/payments/four/get_payment_details_four_integration_test.py
@@ -12,6 +12,7 @@ def test_should_get_payment_details(four_api):
     payment = retriable(callback=four_api.payments.get_payment_details,
                         payment_id=payment_response['id'])
     assert_response(payment,
+                    'http_response',
                     'id',
                     'requested_on',
                     'amount',

--- a/tests/payments/four/increment_payment_authorizations_four_integration_test.py
+++ b/tests/payments/four/increment_payment_authorizations_four_integration_test.py
@@ -18,6 +18,7 @@ def test_should_increment_payment_authorization(four_api):
 
     void_response = four_api.payments.increment_payment_authorization(payment_response['id'], authorization_request)
     assert_response(void_response,
+                    'http_response',
                     'amount',
                     'action_id',
                     'currency',

--- a/tests/payments/four/payment_actions_four_integration_test.py
+++ b/tests/payments/four/payment_actions_four_integration_test.py
@@ -7,12 +7,14 @@ from tests.payments.four.payments_four_test_utils import make_card_payment
 def test_should_get_payment_actions(four_api):
     payment_response = make_card_payment(four_api, capture=True)
 
-    payment_actions = retriable(callback=four_api.payments.get_payment_actions,
-                                predicate=there_are_two_payment_actions,
-                                payment_id=payment_response['id'])
-    assert type(payment_actions) is list
-    assert payment_actions.__len__() > 0
-    for action in payment_actions:
+    response = retriable(callback=four_api.payments.get_payment_actions,
+                         predicate=there_are_two_payment_actions,
+                         payment_id=payment_response['id'])
+    assert_response(response, 'http_response')
+    actions = response['items']
+    assert type(actions) is list
+    assert actions.__len__() > 0
+    for action in actions:
         assert_response(action,
                         'amount',
                         'approved',

--- a/tests/payments/four/refund_payments_four_integration_test.py
+++ b/tests/payments/four/refund_payments_four_integration_test.py
@@ -19,6 +19,7 @@ def test_should_refund_card_payment(four_api):
                                 refund_request=refund_request)
 
     assert_response(refund_response,
+                    'http_response',
                     'reference',
                     'action_id',
                     '_links')
@@ -26,6 +27,7 @@ def test_should_refund_card_payment(four_api):
     payment = retriable(callback=four_api.payments.get_payment_details,
                         payment_id=payment_response['id'])
     assert_response(payment,
+                    'http_response',
                     'balances.total_authorized',
                     'balances.total_captured',
                     'balances.total_refunded')

--- a/tests/payments/four/request_apm_payments_four_integration_test.py
+++ b/tests/payments/four/request_apm_payments_four_integration_test.py
@@ -32,6 +32,7 @@ def test_should_request_ideal_payment(four_api):
     payment_response = retriable(callback=four_api.payments.request_payment,
                                  payment_request=payment_request)
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'status',
                     '_links',
@@ -41,6 +42,7 @@ def test_should_request_ideal_payment(four_api):
     payment_details = retriable(callback=four_api.payments.get_payment_details,
                                 payment_id=payment_response['id'])
     assert_response(payment_details,
+                    'http_response',
                     'id',
                     'requested_on',
                     'source',
@@ -62,6 +64,7 @@ def test_should_request_sofort_payment(four_api):
     payment_response = retriable(callback=four_api.payments.request_payment,
                                  payment_request=payment_request)
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'status',
                     '_links',
@@ -71,6 +74,7 @@ def test_should_request_sofort_payment(four_api):
     payment_details = retriable(callback=four_api.payments.get_payment_details,
                                 payment_id=payment_response['id'])
     assert_response(payment_details,
+                    'http_response',
                     'id',
                     'requested_on',
                     'source',
@@ -129,7 +133,7 @@ def test_should_request_tamara_payment():
     payment_request.processing = processing_settings
     payment_request.processing_channel_id = 'pc_zs5fqhybzc2e3jmq3efvybybpq'
     payment_request.customer = customer_request
-    payment_request.reference = "ORD-5023-4E89"
+    payment_request.reference = 'ORD-5023-4E89'
     payment_request.items = [product]
 
     preview_api = checkout_sdk.OAuthSdk() \

--- a/tests/payments/four/request_payments_four_integration_test.py
+++ b/tests/payments/four/request_payments_four_integration_test.py
@@ -8,6 +8,7 @@ def test_should_request_card_payment(four_api):
     payment_response = make_card_payment(four_api)
 
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'processed_on',
                     'reference',
@@ -51,6 +52,7 @@ def test_should_request_card_3ds_payment(four_api):
     payment_response = make_3ds_card_payment(four_api, False)
 
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'reference',
                     'status',
@@ -66,6 +68,7 @@ def test_should_request_card_3ds_payment_n3d(four_api):
     payment_response = make_3ds_card_payment(four_api, True)
 
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'processed_on',
                     'reference',
@@ -109,6 +112,7 @@ def test_should_request_token_payment(four_api):
     payment_response = make_token_payment(four_api)
 
     assert_response(payment_response,
+                    'http_response',
                     'id',
                     'processed_on',
                     'reference',

--- a/tests/payments/four/void_payments_four_integration_test.py
+++ b/tests/payments/four/void_payments_four_integration_test.py
@@ -15,6 +15,7 @@ def test_should_void_card_payment(four_api):
                               payment_id=payment_response['id'],
                               void_request=void_request)
     assert_response(void_response,
+                    'http_response',
                     'reference',
                     'action_id',
                     '_links')

--- a/tests/payments/hosted/hosted_payments_four_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_four_integration_test.py
@@ -17,7 +17,9 @@ def test_should_create_and_get_hosted_payments_page_details(four_api):
 
     response = four_api.hosted_payments.create_hosted_payments_page_session(request)
 
-    assert_response(response, 'id',
+    assert_response(response,
+                    'http_response',
+                    'id',
                     'reference',
                     '_links',
                     '_links.self',
@@ -25,7 +27,9 @@ def test_should_create_and_get_hosted_payments_page_details(four_api):
 
     hosted_details = four_api.hosted_payments.get_hosted_payments_page_details(response['id'])
 
-    assert_response(hosted_details, 'id',
+    assert_response(hosted_details,
+                    'http_response',
+                    'id',
                     'reference',
                     'status',
                     'amount',
@@ -79,8 +83,8 @@ def create_hosted_payments_request():
     risk_request.enabled = True
 
     billing_descriptor = BillingDescriptor()
-    billing_descriptor.city = "London"
-    billing_descriptor.name = "Awesome name"
+    billing_descriptor.city = 'London'
+    billing_descriptor.name = 'Awesome name'
     billing_descriptor.reference = 'another reference'
 
     request = HostedPaymentsSessionRequest()

--- a/tests/payments/hosted/hosted_payments_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_integration_test.py
@@ -13,7 +13,9 @@ def test_should_create_and_get_hosted_payments_page_details(default_api):
 
     response = default_api.hosted_payments.create_hosted_payments_page_session(request)
 
-    assert_response(response, 'id',
+    assert_response(response,
+                    'http_response',
+                    'id',
                     'reference',
                     '_links',
                     '_links.self',
@@ -21,7 +23,9 @@ def test_should_create_and_get_hosted_payments_page_details(default_api):
 
     hosted_details = default_api.hosted_payments.get_hosted_payments_page_details(response['id'])
 
-    assert_response(hosted_details, 'id',
+    assert_response(hosted_details,
+                    'http_response',
+                    'id',
                     'reference',
                     'status',
                     'amount',

--- a/tests/payments/links/payments_links_four_integration_test.py
+++ b/tests/payments/links/payments_links_four_integration_test.py
@@ -16,7 +16,9 @@ def test_should_create_and_get_payment_link(four_api):
 
     response = four_api.payments_links.create_payment_link(request)
 
-    assert_response(response, 'id',
+    assert_response(response,
+                    'http_response',
+                    'id',
                     'reference',
                     'expires_on',
                     '_links',
@@ -25,13 +27,17 @@ def test_should_create_and_get_payment_link(four_api):
                     'warnings')
 
     for warning in response['warnings']:
-        assert_response(warning, 'code',
+        assert_response(warning,
+                        'http_response',
+                        'code',
                         'value',
                         'description')
 
     hosted_details = four_api.payments_links.get_payment_link(response['id'])
 
-    assert_response(hosted_details, 'id',
+    assert_response(hosted_details,
+                    'http_response',
+                    'id',
                     'reference',
                     'status',
                     'amount',

--- a/tests/payments/links/payments_links_integration_test.py
+++ b/tests/payments/links/payments_links_integration_test.py
@@ -13,7 +13,9 @@ def test_should_create_and_get_payment_link(default_api):
 
     response = default_api.payments_links.create_payment_link(request)
 
-    assert_response(response, 'id',
+    assert_response(response,
+                    'http_response',
+                    'id',
                     'reference',
                     'expires_on',
                     '_links',
@@ -22,13 +24,16 @@ def test_should_create_and_get_payment_link(default_api):
                     'warnings')
 
     for warning in response['warnings']:
-        assert_response(warning, 'code',
+        assert_response(warning,
+                        'code',
                         'value',
                         'description')
 
     hosted_details = default_api.payments_links.get_payment_link(response['id'])
 
-    assert_response(hosted_details, 'id',
+    assert_response(hosted_details,
+                    'http_response',
+                    'id',
                     'reference',
                     'status',
                     'amount',

--- a/tests/payments/payment_actions_integration_test.py
+++ b/tests/payments/payment_actions_integration_test.py
@@ -7,13 +7,14 @@ from tests.payments.payments_test_utils import make_card_payment
 def test_should_get_payment_actions(default_api):
     payment_response = make_card_payment(default_api, capture=True)
 
-    payment_actions = retriable(callback=default_api.payments.get_payment_actions,
-                                predicate=there_are_two_payment_actions,
-                                payment_id=payment_response['id'])
+    response = retriable(callback=default_api.payments.get_payment_actions,
+                         predicate=there_are_two_payment_actions,
+                         payment_id=payment_response['id'])
 
-    assert type(payment_actions) is list
-    assert payment_actions.__len__() > 0
-    for action in payment_actions:
+    actions = response['items']
+    assert type(actions) is list
+    assert actions.__len__() > 0
+    for action in actions:
         assert_response(action,
                         'amount',
                         'approved',

--- a/tests/risk/risk_four_integration_test.py
+++ b/tests/risk/risk_four_integration_test.py
@@ -34,7 +34,7 @@ def test_should_pre_capture_and_authenticate_customer(four_api):
     customer_response = four_api.customers.create(customer)
 
     source_prism = CustomerSourcePrism()
-    source_prism.id = customer_response["id"]
+    source_prism.id = customer_response['id']
 
     authentication_assessment_request(four_api, source_prism)
     pre_capture_assessment_request(four_api, source_prism)
@@ -57,13 +57,13 @@ def test_should_pre_capture_and_authenticate_id(four_api):
     account_holder.phone = phone()
 
     instrument_request = CreateTokenInstrumentRequest()
-    instrument_request.token = card_token_response["token"]
+    instrument_request.token = card_token_response['token']
     instrument_request.account_holder = account_holder
 
     instrument_response = four_api.instruments.create(instrument_request)
 
     source_prism = IdSourcePrism()
-    source_prism.id = instrument_response["id"]
+    source_prism.id = instrument_response['id']
     source_prism.cvv = VisaCard.cvv
 
     authentication_assessment_request(four_api, source_prism)
@@ -83,7 +83,7 @@ def test_should_pre_capture_and_authenticate_token(four_api):
     card_token_response = four_api.tokens.request_card_token(card_token_request)
 
     token_source = RiskRequestTokenSource()
-    token_source.token = card_token_response["token"]
+    token_source.token = card_token_response['token']
     token_source.phone = phone()
     token_source.billing_address = address()
 
@@ -98,8 +98,8 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     request.customer = common_customer_request()
     request.payment = get_risk_payment()
     request.shipping = get_risk_shipping_details()
-    request.reference = "ORD-1011-87AH"
-    request.description = "Set of 3 masks"
+    request.reference = 'ORD-1011-87AH'
+    request.description = 'Set of 3 masks'
     request.amount = 6540
     request.currency = Currency.GBP
     request.device = get_device()
@@ -111,11 +111,12 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     response = api_client.risk.request_pre_authentication_risk_scan(request)
 
     assert_response(response,
-                    "assessment_id",
-                    "result",
-                    "result.decision",
-                    "result.details",
-                    "_links")
+                    'http_response',
+                    'assessment_id',
+                    'result',
+                    'result.decision',
+                    'result.details',
+                    '_links')
 
 
 def pre_capture_assessment_request(api_client: CheckoutApi, request_source: RiskPaymentRequestSource):
@@ -123,9 +124,9 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     authentication_result.attempted = True
     authentication_result.challenged = True
     authentication_result.liability_shifted = True
-    authentication_result.method = "3ds"
+    authentication_result.method = '3ds'
     authentication_result.succeeded = True
-    authentication_result.version = "2.0"
+    authentication_result.version = '2.0'
 
     authorization_result = AuthorizationResult()
     authorization_result.avs_code = 'Y'
@@ -150,11 +151,12 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     response = api_client.risk.request_pre_capture_risk_scan(request)
 
     assert_response(response,
-                    "assessment_id",
-                    "result",
-                    "result.decision",
-                    "result.details",
-                    "_links")
+                    'http_response',
+                    'assessment_id',
+                    'result',
+                    'result.decision',
+                    'result.details',
+                    '_links')
 
 
 def get_risk_shipping_details() -> RiskShippingDetails:
@@ -165,23 +167,23 @@ def get_risk_shipping_details() -> RiskShippingDetails:
 
 def get_device() -> Device:
     location = Location()
-    location.longitude = "0.1313"
-    location.latitude = "51.5107"
+    location.longitude = '0.1313'
+    location.latitude = '51.5107'
 
     device = Device()
     device.location = location
-    device.type = "Phone"
-    device.os = "ISO"
-    device.model = "iPhone X"
+    device.type = 'Phone'
+    device.os = 'ISO'
+    device.model = 'iPhone X'
     device.date = datetime.now(timezone.utc)
-    device.user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, " \
-                        "like Gecko) Version/11.0 Mobile/15A372 Safari/604.1 "
-    device.fingerprint = "34304a9e3fg09302"
+    device.user_agent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, ' \
+                        'like Gecko) Version/11.0 Mobile/15A372 Safari/604.1 '
+    device.fingerprint = '34304a9e3fg09302'
     return device
 
 
 def get_risk_payment() -> RiskPayment:
     risk_payment = RiskPayment()
-    risk_payment.psp = "CheckoutSdk.com"
-    risk_payment.id = "78453878"
+    risk_payment.psp = 'CheckoutSdk.com'
+    risk_payment.id = '78453878'
     return risk_payment

--- a/tests/risk/risk_integration_test.py
+++ b/tests/risk/risk_integration_test.py
@@ -34,7 +34,7 @@ def test_should_pre_capture_and_authenticate_customer(default_api):
     customer_response = default_api.customers.create(customer)
 
     source_prism = CustomerSourcePrism()
-    source_prism.id = customer_response["id"]
+    source_prism.id = customer_response['id']
 
     authentication_assessment_request(default_api, source_prism)
     pre_capture_assessment_request(default_api, source_prism)
@@ -58,13 +58,13 @@ def test_should_pre_capture_and_authenticate_id(default_api):
 
     instrument_request = CreateInstrumentRequest()
     instrument_request.type = InstrumentType.TOKEN
-    instrument_request.token = card_token_response["token"]
+    instrument_request.token = card_token_response['token']
     instrument_request.account_holder = account_holder
 
     instrument_response = default_api.instruments.create(instrument_request)
 
     source_prism = IdSourcePrism()
-    source_prism.id = instrument_response["id"]
+    source_prism.id = instrument_response['id']
     source_prism.cvv = VisaCard.cvv
 
     authentication_assessment_request(default_api, source_prism)
@@ -84,7 +84,7 @@ def test_should_pre_capture_and_authenticate_token(default_api):
     card_token_response = default_api.tokens.request_card_token(card_token_request)
 
     token_source = RiskRequestTokenSource()
-    token_source.token = card_token_response["token"]
+    token_source.token = card_token_response['token']
     token_source.phone = phone()
     token_source.billing_address = address()
 
@@ -99,8 +99,8 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     request.customer = common_customer_request()
     request.payment = get_risk_payment()
     request.shipping = get_risk_shipping_details()
-    request.reference = "ORD-1011-87AH"
-    request.description = "Set of 3 masks"
+    request.reference = 'ORD-1011-87AH'
+    request.description = 'Set of 3 masks'
     request.amount = 6540
     request.currency = Currency.GBP
     request.device = get_device()
@@ -112,11 +112,12 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     response = api_client.risk.request_pre_authentication_risk_scan(request)
 
     assert_response(response,
-                    "assessment_id",
-                    "result",
-                    "result.decision",
-                    "result.details",
-                    "_links")
+                    'http_response',
+                    'assessment_id',
+                    'result',
+                    'result.decision',
+                    'result.details',
+                    '_links')
 
 
 def pre_capture_assessment_request(api_client: CheckoutApi, request_source: RiskPaymentRequestSource):
@@ -124,9 +125,9 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     authentication_result.attempted = True
     authentication_result.challenged = True
     authentication_result.liability_shifted = True
-    authentication_result.method = "3ds"
+    authentication_result.method = '3ds'
     authentication_result.succeeded = True
-    authentication_result.version = "2.0"
+    authentication_result.version = '2.0'
 
     authorization_result = AuthorizationResult()
     authorization_result.avs_code = 'Y'
@@ -151,11 +152,12 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     response = api_client.risk.request_pre_capture_risk_scan(request)
 
     assert_response(response,
-                    "assessment_id",
-                    "result",
-                    "result.decision",
-                    "result.details",
-                    "_links")
+                    'http_response',
+                    'assessment_id',
+                    'result',
+                    'result.decision',
+                    'result.details',
+                    '_links')
 
 
 def get_risk_shipping_details() -> RiskShippingDetails:
@@ -166,23 +168,23 @@ def get_risk_shipping_details() -> RiskShippingDetails:
 
 def get_device() -> Device:
     location = Location()
-    location.longitude = "0.1313"
-    location.latitude = "51.5107"
+    location.longitude = '0.1313'
+    location.latitude = '51.5107'
 
     device = Device()
     device.location = location
-    device.type = "Phone"
-    device.os = "ISO"
-    device.model = "iPhone X"
+    device.type = 'Phone'
+    device.os = 'ISO'
+    device.model = 'iPhone X'
     device.date = datetime.now(timezone.utc)
-    device.user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, " \
-                        "like Gecko) Version/11.0 Mobile/15A372 Safari/604.1 "
-    device.fingerprint = "34304a9e3fg09302"
+    device.user_agent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, ' \
+                        'like Gecko) Version/11.0 Mobile/15A372 Safari/604.1 '
+    device.fingerprint = '34304a9e3fg09302'
     return device
 
 
 def get_risk_payment() -> RiskPayment:
     risk_payment = RiskPayment()
-    risk_payment.psp = "CheckoutSdk.com"
-    risk_payment.id = "78453878"
+    risk_payment.psp = 'CheckoutSdk.com'
+    risk_payment.id = '78453878'
     return risk_payment

--- a/tests/sessions/complete_sessions_integration_test.py
+++ b/tests/sessions/complete_sessions_integration_test.py
@@ -21,11 +21,11 @@ def test_try_complete_sessions(oauth_api: CheckoutApi):
         oauth_api.sessions.complete_session(session_id)
         pytest.fail()
     except CheckoutApiException as err:
-        assert err.args[0] == "The API response status code (403) does not indicate success."
-        assert err.error_details['error_codes'][0] == 'update_not_allowed_due_to_state'
+        assert err.args[0] == 'The API response status code (403) does not indicate success.'
+        assert err.error_details[0] == 'update_not_allowed_due_to_state'
 
     try:
         oauth_api.sessions.complete_session(session_id, session_secret)
         pytest.fail()
     except CheckoutApiException as err:
-        assert err.error_details['error_codes'][0] == 'update_not_allowed_due_to_state'
+        assert err.error_details[0] == 'update_not_allowed_due_to_state'

--- a/tests/sessions/sessions_test_utils.py
+++ b/tests/sessions/sessions_test_utils.py
@@ -1,5 +1,6 @@
 from checkout_sdk.common.enums import Country, Currency, ChallengeIndicator
-from checkout_sdk.sessions.sessions import BrowserSession, ThreeDsMethodCompletion, SessionAddress, SessionMarketplaceData, \
+from checkout_sdk.sessions.sessions import BrowserSession, ThreeDsMethodCompletion, SessionAddress, \
+    SessionMarketplaceData, \
     SessionsBillingDescriptor, NonHostedCompletionInfo, SessionRequest, ChannelData, \
     TransactionType, AppSession, SdkEphemeralPublicKey, SdkInterfaceType, UIElements, HostedCompletionInfo, \
     AuthenticationType, Category, SessionCardSource
@@ -25,18 +26,18 @@ def get_browser_session():
 
 def get_app_session():
     sdk_ephemeral_public_key = SdkEphemeralPublicKey()
-    sdk_ephemeral_public_key.kty = "EC"
-    sdk_ephemeral_public_key.crv = "P-256"
-    sdk_ephemeral_public_key.x = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU"
-    sdk_ephemeral_public_key.y = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+    sdk_ephemeral_public_key.kty = 'EC'
+    sdk_ephemeral_public_key.crv = 'P-256'
+    sdk_ephemeral_public_key.x = 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU'
+    sdk_ephemeral_public_key.y = 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0'
 
     app_session = AppSession()
-    app_session.sdk_app_id = "dbd64fcb-c19a-4728-8849-e3d50bfdde39"
+    app_session.sdk_app_id = 'dbd64fcb-c19a-4728-8849-e3d50bfdde39'
     app_session.sdk_max_timeout = 5
-    app_session.sdk_encrypted_data = "{}"
+    app_session.sdk_encrypted_data = '{}'
     app_session.sdk_ephem_pub_key = sdk_ephemeral_public_key
-    app_session.sdk_reference_number = "3DS_LOA_SDK_PPFU_020100_00007"
-    app_session.sdk_transaction_id = "b2385523-a66c-4907-ac3c-91848e8c0067"
+    app_session.sdk_reference_number = '3DS_LOA_SDK_PPFU_020100_00007'
+    app_session.sdk_transaction_id = 'b2385523-a66c-4907-ac3c-91848e8c0067'
     app_session.sdk_interface_type = SdkInterfaceType.BOTH
     app_session.sdk_ui_elements = [UIElements.SINGLE_SELECT, UIElements.HTML_OTHER]
 
@@ -48,10 +49,10 @@ def get_non_hosted_session(channel_data: ChannelData,
                            challenge_indicator_type: ChallengeIndicator,
                            transaction_type: TransactionType):
     billing_address = SessionAddress()
-    billing_address.address_line1 = "CheckoutSdk.com"
-    billing_address.address_line2 = "90 Tottenham Court Road"
-    billing_address.city = "London"
-    billing_address.state = "ENG"
+    billing_address.address_line1 = 'CheckoutSdk.com'
+    billing_address.address_line2 = '90 Tottenham Court Road'
+    billing_address.city = 'London'
+    billing_address.state = 'ENG'
     billing_address.country = Country.GB
 
     session_card_source = SessionCardSource()
@@ -59,40 +60,40 @@ def get_non_hosted_session(channel_data: ChannelData,
     session_card_source.number = VisaCard.number
     session_card_source.expiry_month = VisaCard.expiry_month
     session_card_source.expiry_year = VisaCard.expiry_year
-    session_card_source.name = "John Doe"
+    session_card_source.name = 'John Doe'
     session_card_source.email = random_email()
     session_card_source.home_phone = phone()
     session_card_source.work_phone = phone()
     session_card_source.mobile_phone = phone()
 
     shipping_address = SessionAddress()
-    shipping_address.address_line1 = "CheckoutSdk.com"
-    shipping_address.address_line2 = "ABC building"
-    shipping_address.address_line3 = "14 Wells Mews"
-    shipping_address.city = "London"
-    shipping_address.state = "ENG"
-    shipping_address.zip = "W1T 4TJ"
+    shipping_address.address_line1 = 'CheckoutSdk.com'
+    shipping_address.address_line2 = 'ABC building'
+    shipping_address.address_line3 = '14 Wells Mews'
+    shipping_address.city = 'London'
+    shipping_address.state = 'ENG'
+    shipping_address.zip = 'W1T 4TJ'
     shipping_address.country = Country.GB
 
     marketplace_data = SessionMarketplaceData()
-    marketplace_data.sub_entity_id = "ent_ocw5i74vowfg2edpy66izhts2u"
+    marketplace_data.sub_entity_id = 'ent_ocw5i74vowfg2edpy66izhts2u'
 
     billing_descriptor = SessionsBillingDescriptor()
-    billing_descriptor.name = "SUPERHEROES.COM"
+    billing_descriptor.name = 'SUPERHEROES.COM'
 
     non_hosted_completion_info = NonHostedCompletionInfo()
-    non_hosted_completion_info.callback_url = "https://merchant.com/callback"
+    non_hosted_completion_info.callback_url = 'https://merchant.com/callback'
 
     session_request = SessionRequest()
     session_request.source = session_card_source
     session_request.amount = 6540
     session_request.currency = Currency.USD
-    session_request.processing_channel_id = "pc_5jp2az55l3cuths25t5p3xhwru"
+    session_request.processing_channel_id = 'pc_5jp2az55l3cuths25t5p3xhwru'
     session_request.marketplace = marketplace_data
     session_request.authentication_category = authentication_category
     session_request.challenge_indicator = challenge_indicator_type
     session_request.billing_descriptor = billing_descriptor
-    session_request.reference = "ORD-5023-4E89"
+    session_request.reference = 'ORD-5023-4E89'
     session_request.transaction_type = transaction_type
     session_request.shipping_address = shipping_address
     session_request.completion = non_hosted_completion_info
@@ -103,31 +104,31 @@ def get_non_hosted_session(channel_data: ChannelData,
 
 def get_hosted_session():
     shipping_address = SessionAddress()
-    shipping_address.address_line1 = "CheckoutSdk.com"
-    shipping_address.address_line2 = "90 Tottenham Court Road"
-    shipping_address.city = "London"
-    shipping_address.state = "ENG"
-    shipping_address.zip = "W1T 4TJ"
+    shipping_address.address_line1 = 'CheckoutSdk.com'
+    shipping_address.address_line2 = '90 Tottenham Court Road'
+    shipping_address.city = 'London'
+    shipping_address.state = 'ENG'
+    shipping_address.zip = 'W1T 4TJ'
     shipping_address.country = Country.GB
 
     session_card_source = SessionCardSource()
-    session_card_source.number = "4485040371536584"
+    session_card_source.number = '4485040371536584'
     session_card_source.expiry_month = 1
     session_card_source.expiry_year = 2030
 
     hosted_completion_info = HostedCompletionInfo()
-    hosted_completion_info.failure_url = "https://example.com/sessions/fail"
-    hosted_completion_info.success_url = "https://example.com/sessions/success"
+    hosted_completion_info.failure_url = 'https://example.com/sessions/fail'
+    hosted_completion_info.success_url = 'https://example.com/sessions/success'
 
     session_request = SessionRequest()
     session_request.source = session_card_source
     session_request.amount = 100
     session_request.currency = Currency.USD
-    session_request.processing_channel_id = "pc_5jp2az55l3cuths25t5p3xhwru"
+    session_request.processing_channel_id = 'pc_5jp2az55l3cuths25t5p3xhwru'
     session_request.authentication_type = AuthenticationType.REGULAR
     session_request.authentication_category = Category.PAYMENT
     session_request.challenge_indicator = ChallengeIndicator.NO_PREFERENCE
-    session_request.reference = "ORD-5023-4E89"
+    session_request.reference = 'ORD-5023-4E89'
     session_request.transaction_type = TransactionType.GOODS_SERVICE
     session_request.shipping_address = shipping_address
     session_request.completion = hosted_completion_info

--- a/tests/tokens/tokens_four_integration_test.py
+++ b/tests/tokens/tokens_four_integration_test.py
@@ -15,6 +15,7 @@ def test_should_create_card_token(four_api):
     response = four_api.tokens.request_card_token(card_token_request)
 
     assert_response(response,
+                    'http_response',
                     'token',
                     'type',
                     'expires_on',

--- a/tests/tokens/tokens_integration_test.py
+++ b/tests/tokens/tokens_integration_test.py
@@ -15,6 +15,7 @@ def test_should_create_card_token(default_api):
     response = default_api.tokens.request_card_token(request)
 
     assert_response(response,
+                    'http_response',
                     'token',
                     'type',
                     'expires_on',

--- a/tests/workflows/workflow_events_integration_test.py
+++ b/tests/workflows/workflow_events_integration_test.py
@@ -4,13 +4,15 @@ from tests.workflows.workflows_test_utils import create_workflow, clean_workflow
 
 
 def test_should_get_event_types(four_api):
-    event_types = four_api.workflows.get_event_types()
+    response = four_api.workflows.get_event_types()
 
-    assert event_types is not None
-    assert event_types.__len__() == 8
+    results = response['items']
+    assert results is not None
+    assert results.__len__() == 8
 
-    for event_type in event_types:
-        assert_response(event_type, 'id',
+    for event_type in results:
+        assert_response(event_type,
+                        'id',
                         'description',
                         'display_name',
                         'events')

--- a/tests/workflows/workflow_integration_test.py
+++ b/tests/workflows/workflow_integration_test.py
@@ -9,7 +9,9 @@ def test__should_create_and_get_workflows(four_api):
 
     workflow_response = four_api.workflows.get_workflow(workflow['id'])
 
-    assert_response(workflow_response, 'id',
+    assert_response(workflow_response,
+                    'http_response',
+                    'id',
                     'name',
                     'active',
                     'actions',
@@ -51,7 +53,9 @@ def test__should_create_and_update_workflow(four_api):
 
     update_workflow_response = four_api.workflows.update_workflow(workflow['id'], update_workflow_request)
 
-    assert_response(update_workflow_response, 'name',
+    assert_response(update_workflow_response,
+                    'http_response',
+                    'name',
                     'active')
 
     assert update_workflow_request.name == update_workflow_response['name']
@@ -65,7 +69,9 @@ def test__should_update_workflow_action(four_api):
 
     workflow_response = four_api.workflows.get_workflow(workflow['id'])
 
-    assert_response(workflow_response, 'id',
+    assert_response(workflow_response,
+                    'http_response',
+                    'id',
                     'name',
                     'active',
                     'actions',
@@ -97,7 +103,9 @@ def test__should_update_workflow_condition(four_api):
 
     workflow_response = four_api.workflows.get_workflow(workflow['id'])
 
-    assert_response(workflow_response, 'id',
+    assert_response(workflow_response,
+                    'http_response',
+                    'id',
                     'name',
                     'active',
                     'actions',
@@ -109,20 +117,20 @@ def test__should_update_workflow_condition(four_api):
     assert condition_event is not None
 
     condition_request = EventWorkflowConditionRequest()
-    condition_request.events = {'gateway': ["card_verified",
-                                            "card_verification_declined",
-                                            "payment_approved",
-                                            "payment_pending",
-                                            "payment_declined",
-                                            "payment_voided",
-                                            "payment_captured",
-                                            "payment_refunded"],
-                                'dispute': ["dispute_canceled",
-                                            "dispute_evidence_required",
-                                            "dispute_expired",
-                                            "dispute_lost",
-                                            "dispute_resolved",
-                                            "dispute_won"]}
+    condition_request.events = {'gateway': ['card_verified',
+                                            'card_verification_declined',
+                                            'payment_approved',
+                                            'payment_pending',
+                                            'payment_declined',
+                                            'payment_voided',
+                                            'payment_captured',
+                                            'payment_refunded'],
+                                'dispute': ['dispute_canceled',
+                                            'dispute_evidence_required',
+                                            'dispute_expired',
+                                            'dispute_lost',
+                                            'dispute_resolved',
+                                            'dispute_won']}
 
     four_api.workflows.update_workflow_condition(workflow['id'], condition_event['id'], condition_request)
 

--- a/tests/workflows/workflow_reflow_integration_test.py
+++ b/tests/workflows/workflow_reflow_integration_test.py
@@ -92,7 +92,8 @@ def __get_subject_event(four_api: CheckoutApi, subject_id: str):
                          subject_id=subject_id)
 
     approved_event = __find_payment_approved(response)
-    assert_response(approved_event, 'id',
+    assert_response(approved_event,
+                    'id',
                     'type',
                     'timestamp')
 

--- a/tests/workflows/workflows_test_utils.py
+++ b/tests/workflows/workflows_test_utils.py
@@ -17,7 +17,7 @@ def create_workflow(four_api):
     signature.method = 'HMACSHA256'
 
     action_request = WebhookWorkflowActionRequest()
-    action_request.url = "https://google.com/fail"
+    action_request.url = 'https://google.com/fail'
     action_request.headers = {}
     action_request.signature = signature
 
@@ -25,24 +25,24 @@ def create_workflow(four_api):
     entity_condition_request.entities = [__WORKFLOW_ENTITY_ID]
 
     event_condition_request = EventWorkflowConditionRequest()
-    event_condition_request.events = {'gateway': ["payment_approved",
-                                                  "payment_declined",
-                                                  "card_verification_declined",
-                                                  "card_verified",
-                                                  "payment_authorization_incremented",
-                                                  "payment_authorization_increment_declined",
-                                                  "payment_capture_declined",
-                                                  "payment_captured",
-                                                  "payment_refund_declined",
-                                                  "payment_refunded",
-                                                  "payment_void_declined",
-                                                  "payment_voided"],
-                                      'dispute': ["dispute_canceled",
-                                                  "dispute_evidence_required",
-                                                  "dispute_expired",
-                                                  "dispute_lost",
-                                                  "dispute_resolved",
-                                                  "dispute_won"]}
+    event_condition_request.events = {'gateway': ['payment_approved',
+                                                  'payment_declined',
+                                                  'card_verification_declined',
+                                                  'card_verified',
+                                                  'payment_authorization_incremented',
+                                                  'payment_authorization_increment_declined',
+                                                  'payment_capture_declined',
+                                                  'payment_captured',
+                                                  'payment_refund_declined',
+                                                  'payment_refunded',
+                                                  'payment_void_declined',
+                                                  'payment_voided'],
+                                      'dispute': ['dispute_canceled',
+                                                  'dispute_evidence_required',
+                                                  'dispute_expired',
+                                                  'dispute_lost',
+                                                  'dispute_resolved',
+                                                  'dispute_won']}
 
     processing_channel_condition_request = ProcessingChannelWorkflowConditionRequest()
     processing_channel_condition_request.processing_channels = [__PROCESSING_CHANNEL_ID]


### PR DESCRIPTION
This commit appends `http_response` with the full http response payload to any operation response. Any response that consists in a `list` will now be returned in a separate property named `results`. Plus, `http_response` has also been added to `CheckoutApiException`.