### PR TITLE
Always return from SDK operations

### DIFF
--- a/checkout_sdk/customers/customers_client.py
+++ b/checkout_sdk/customers/customers_client.py
@@ -26,4 +26,4 @@ class CustomersClient(Client):
                                       customer_request)
 
     def delete(self, customer_id: str):
-        self._api_client.delete(self.build_path(self.__CUSTOMERS_PATH, customer_id), self._sdk_authorization())
+        return self._api_client.delete(self.build_path(self.__CUSTOMERS_PATH, customer_id), self._sdk_authorization())

--- a/checkout_sdk/customers/customers_client_four.py
+++ b/checkout_sdk/customers/customers_client_four.py
@@ -26,4 +26,4 @@ class CustomersClient(Client):
                                       customer_request)
 
     def delete(self, customer_id: str):
-        self._api_client.delete(self.build_path(self.__CUSTOMERS_PATH, customer_id), self._sdk_authorization())
+        return self._api_client.delete(self.build_path(self.__CUSTOMERS_PATH, customer_id), self._sdk_authorization())

--- a/checkout_sdk/disputes/disputes_client.py
+++ b/checkout_sdk/disputes/disputes_client.py
@@ -25,17 +25,17 @@ class DisputesClient(FilesClient):
         return self._api_client.get(self.build_path(self.__DISPUTES_PATH, dispute_id), self._sdk_authorization())
 
     def accept(self, dispute_id: str):
-        self._api_client.post(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__ACCEPT_PATH),
-                              self._sdk_authorization())
+        return self._api_client.post(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__ACCEPT_PATH),
+                                     self._sdk_authorization())
 
     def put_evidence(self, dispute_id: str, dispute_evidence_request: DisputeEvidenceRequest):
-        self._api_client.put(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__EVIDENCE_PATH),
-                             self._sdk_authorization(), dispute_evidence_request)
+        return self._api_client.put(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__EVIDENCE_PATH),
+                                    self._sdk_authorization(), dispute_evidence_request)
 
     def get_evidence(self, dispute_id: str):
         return self._api_client.get(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__EVIDENCE_PATH),
                                     self._sdk_authorization())
 
     def submit_evidence(self, dispute_id: str):
-        self._api_client.post(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__EVIDENCE_PATH),
-                              self._sdk_authorization())
+        return self._api_client.post(self.build_path(self.__DISPUTES_PATH, dispute_id, self.__EVIDENCE_PATH),
+                                     self._sdk_authorization())

--- a/checkout_sdk/instruments/instruments_client.py
+++ b/checkout_sdk/instruments/instruments_client.py
@@ -28,4 +28,4 @@ class InstrumentsClient(Client):
             update_instrument_request)
 
     def delete(self, instrument_id: str):
-        self._api_client.delete(self.build_path(self.__INSTRUMENTS, instrument_id), self._sdk_authorization())
+        return self._api_client.delete(self.build_path(self.__INSTRUMENTS, instrument_id), self._sdk_authorization())

--- a/checkout_sdk/instruments/instruments_four_client.py
+++ b/checkout_sdk/instruments/instruments_four_client.py
@@ -31,7 +31,7 @@ class InstrumentsClient(Client):
             update_instrument_request)
 
     def delete(self, instrument_id: str):
-        self._api_client.delete(self.build_path(self.__INSTRUMENTS, instrument_id), self._sdk_authorization())
+        return self._api_client.delete(self.build_path(self.__INSTRUMENTS, instrument_id), self._sdk_authorization())
 
     def get_bank_account_field_formatting(self, country: Country, currency: Currency,
                                           bank_account_field_query: BankAccountFieldQuery):

--- a/tests/customers/customers_client_test.py
+++ b/tests/customers/customers_client_test.py
@@ -24,5 +24,5 @@ class TestCustomersClient:
         assert client.update('customer_id', CustomerRequest()) == 'response'
 
     def test_should_delete_customer(self, mocker, client: CustomersClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.delete')
-        client.delete('customer_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.delete', return_value='response')
+        assert client.delete('customer_id') == 'response'

--- a/tests/customers/customers_four_client_test.py
+++ b/tests/customers/customers_four_client_test.py
@@ -24,5 +24,5 @@ class TestCustomersClient:
         assert client.update('customer_id', CustomerRequest()) == 'response'
 
     def test_should_delete_customer(self, mocker, client: CustomersClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.delete')
-        client.delete('customer_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.delete', return_value='response')
+        assert client.delete('customer_id') == 'response'

--- a/tests/customers/customers_four_integration_test.py
+++ b/tests/customers/customers_four_integration_test.py
@@ -40,7 +40,8 @@ def test_should_create_and_update_customer(four_api):
 
 def test_should_create_and_delete_customer(four_api):
     customer_id = create_customer(four_api, random_email())
-    four_api.customers.delete(customer_id)
+    response = four_api.customers.delete(customer_id)
+    assert_response(response, 'http_response')
 
     try:
         four_api.customers.get(customer_id)

--- a/tests/customers/customers_integration_test.py
+++ b/tests/customers/customers_integration_test.py
@@ -40,7 +40,8 @@ def test_should_create_and_update_customer(default_api):
 
 def test_should_create_and_delete_customer(default_api):
     customer_id = create_customer(default_api, random_email())
-    default_api.customers.delete(customer_id)
+    response = default_api.customers.delete(customer_id)
+    assert_response(response, 'http_response')
 
     try:
         default_api.customers.get(customer_id)

--- a/tests/disputes/disputes_client_test.py
+++ b/tests/disputes/disputes_client_test.py
@@ -21,20 +21,20 @@ class TestDisputesClient:
         assert client.get_dispute_details('dispute_id') == 'response'
 
     def test_should_accept_dispute(self, mocker, client: DisputesClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.post')
-        client.accept('customer_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.accept('customer_id') == 'response'
 
     def test_should_put_evidence(self, mocker, client: DisputesClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.put')
-        client.put_evidence('dispute_id', DisputeEvidenceRequest())
+        mocker.patch('checkout_sdk.api_client.ApiClient.put', return_value='response')
+        assert client.put_evidence('dispute_id', DisputeEvidenceRequest()) == 'response'
 
     def test_should_get_evidence(self, mocker, client: DisputesClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
         assert client.get_evidence('dispute_id') == 'response'
 
     def test_should_submit_evidence(self, mocker, client: DisputesClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.post')
-        client.submit_evidence('dispute_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.submit_evidence('dispute_id') == 'response'
 
     def test_should_upload_file(self, mocker, client: DisputesClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.submit_file', return_value='response')

--- a/tests/disputes/disputes_integration_test.py
+++ b/tests/disputes/disputes_integration_test.py
@@ -86,7 +86,8 @@ def test_should_test_full_disputes_workflow(default_api):
 
     dispute_id = query_response['data'][0]['id']
 
-    default_api.disputes.put_evidence(dispute_id, evidence_request)
+    put_response = default_api.disputes.put_evidence(dispute_id, evidence_request)
+    assert_response(put_response, 'http_response')
 
     evidence = default_api.disputes.get_evidence(dispute_id)
     assert_response(evidence,

--- a/tests/instruments/instruments_client_test.py
+++ b/tests/instruments/instruments_client_test.py
@@ -24,5 +24,5 @@ class TestInstrumentsClient:
         assert client.update('instrument_id', UpdateInstrumentRequest()) == 'response'
 
     def test_should_delete_instrument(self, mocker, client: InstrumentsClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.delete')
-        client.delete('instrument_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.delete', return_value='response')
+        assert client.delete('instrument_id') == 'response'

--- a/tests/instruments/instruments_four_client_test.py
+++ b/tests/instruments/instruments_four_client_test.py
@@ -26,8 +26,8 @@ class TestInstrumentsClient:
         assert client.update('instrument_id', UpdateCardInstrumentRequest()) == 'response'
 
     def test_should_delete_instrument(self, mocker, client: InstrumentsClient):
-        mocker.patch('checkout_sdk.api_client.ApiClient.delete')
-        client.delete('instrument_id')
+        mocker.patch('checkout_sdk.api_client.ApiClient.delete', return_value='response')
+        assert client.delete('instrument_id') == 'response'
 
     def test_should_get_bank_account_field_formatting(self, mocker, client: InstrumentsClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')


### PR DESCRIPTION
This commit refactors certain operations to always return the response containing `http_response`,