### PR TITLE
Refactor `http_response` to `http_metadata` and added specific mapping

### DIFF
--- a/checkout_sdk/api_client.py
+++ b/checkout_sdk/api_client.py
@@ -14,6 +14,7 @@ from checkout_sdk.files.files import FileRequest
 from checkout_sdk.json_serializer import JsonSerializer
 from checkout_sdk.properties import VERSION
 from checkout_sdk.sdk_authorization import SdkAuthorization
+from checkout_sdk.utils import map_to_http_metadata
 
 
 def get_file_request(file_request: FileRequest, multipart_file=None):
@@ -122,7 +123,8 @@ class ApiClient:
             error = err.strerror
             raise CheckoutException(error) from err
 
+        http_metadata = map_to_http_metadata(response)
         if response.text:
-            return ResponseWrapper(response, response.json())
+            return ResponseWrapper(http_metadata, response.json())
         else:
-            return ResponseWrapper(http_response=response)
+            return ResponseWrapper(http_metadata)

--- a/checkout_sdk/checkout_response.py
+++ b/checkout_sdk/checkout_response.py
@@ -1,8 +1,8 @@
 class ResponseWrapper:
 
-    def __init__(self, http_response=None, data=None):
-        if http_response is not None:
-            setattr(self, 'http_response', http_response)
+    def __init__(self, http_metadata=None, data=None):
+        if http_metadata is not None:
+            setattr(self, 'http_metadata', http_metadata)
         if data is not None:
             if self._is_collection(data):
                 setattr(self, 'items', self._wrap(data))

--- a/checkout_sdk/exception.py
+++ b/checkout_sdk/exception.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from checkout_sdk.authorization_type import AuthorizationType
+from checkout_sdk.utils import map_to_http_metadata
 
 
 class CheckoutException(Exception):
@@ -29,17 +30,13 @@ class CheckoutAuthorizationException(CheckoutException):
 
 
 class CheckoutApiException(CheckoutException):
-    http_status_code: int
-    http_response: dict
-    request_id: str
+    http_metadata: dict
     error_details: dict
 
     def __init__(self, response):
-        self.http_status_code = response.status_code
-        self.http_response = response
+        self.http_metadata = map_to_http_metadata(response)
         if response.text:
             payload = response.json()
-            self.request_id = payload['request_id'] if 'request_id' in payload else None
             self.error_details = payload['error_codes'] if 'error_codes' in payload else None
         super().__init__('The API response status code ({}) does not indicate success.'
                          .format(response.status_code))

--- a/checkout_sdk/http_metadata.py
+++ b/checkout_sdk/http_metadata.py
@@ -1,0 +1,4 @@
+class HttpMetadata:
+    reason: str
+    status_code: int
+    headers: map

--- a/checkout_sdk/utils.py
+++ b/checkout_sdk/utils.py
@@ -1,0 +1,11 @@
+from checkout_sdk.http_metadata import HttpMetadata
+
+
+def map_to_http_metadata(response):
+    if response is None:
+        return None
+    http_metadata = HttpMetadata()
+    http_metadata.reason_phrase = response.reason
+    http_metadata.status_code = response.status_code
+    http_metadata.headers = response.headers
+    return http_metadata

--- a/tests/apm/ideal_four_integration_test.py
+++ b/tests/apm/ideal_four_integration_test.py
@@ -6,7 +6,7 @@ from tests.checkout_test_utils import assert_response
 def test_should_get_info(four_api):
     response = four_api.ideal.get_info()
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     '_links',
                     '_links.self',
                     '_links.ideal:issuers',
@@ -16,7 +16,7 @@ def test_should_get_info(four_api):
 def test_should_get_issuers(four_api):
     response = four_api.ideal.get_issuers()
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'countries',
                     '_links',
                     '_links.self')

--- a/tests/apm/ideal_integration_test.py
+++ b/tests/apm/ideal_integration_test.py
@@ -6,7 +6,7 @@ from tests.checkout_test_utils import assert_response
 def test_should_get_info(default_api):
     response = default_api.ideal.get_info()
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     '_links',
                     '_links.self',
                     '_links.ideal:issuers',
@@ -16,7 +16,7 @@ def test_should_get_info(default_api):
 def test_should_get_issuers(default_api):
     response = default_api.ideal.get_issuers()
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'countries',
                     '_links',
                     '_links.self')

--- a/tests/apm/klarna_integration_test.py
+++ b/tests/apm/klarna_integration_test.py
@@ -24,14 +24,14 @@ def test_should_create_and_get_klarna_session(default_api):
 
     create_response = default_api.klarna.create_credit_session(credit_session_request)
     assert_response(create_response,
-                    'http_response',
+                    'http_metadata',
                     'session_id',
                     'client_token',
                     'payment_method_categories')
 
     create_response = default_api.klarna.get_credit_session(create_response.session_id)
     assert_response(create_response,
-                    'http_response',
+                    'http_metadata',
                     'client_token',
                     'purchase_country',
                     'currency',

--- a/tests/customers/customers_four_integration_test.py
+++ b/tests/customers/customers_four_integration_test.py
@@ -12,7 +12,7 @@ def test_should_create_and_get_customer(four_api):
     customer_id = create_customer(four_api, email)
     response = four_api.customers.get(customer_id)
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'email',
                     'name',
                     'phone')
@@ -30,7 +30,7 @@ def test_should_create_and_update_customer(four_api):
 
     response_update = four_api.customers.get(customer_id)
     assert_response(response_update,
-                    'http_response',
+                    'http_metadata',
                     'email',
                     'name',
                     'phone')
@@ -41,7 +41,7 @@ def test_should_create_and_update_customer(four_api):
 def test_should_create_and_delete_customer(four_api):
     customer_id = create_customer(four_api, random_email())
     response = four_api.customers.delete(customer_id)
-    assert_response(response, 'http_response')
+    assert_response(response, 'http_metadata')
 
     try:
         four_api.customers.get(customer_id)

--- a/tests/customers/customers_integration_test.py
+++ b/tests/customers/customers_integration_test.py
@@ -12,7 +12,7 @@ def test_should_create_and_get_customer(default_api):
     customer_id = create_customer(default_api, email)
     response = default_api.customers.get(customer_id)
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'email',
                     'name',
                     'phone')
@@ -30,7 +30,7 @@ def test_should_create_and_update_customer(default_api):
 
     response_update = default_api.customers.get(customer_id)
     assert_response(response_update,
-                    'http_response',
+                    'http_metadata',
                     'email',
                     'name',
                     'phone')
@@ -41,7 +41,7 @@ def test_should_create_and_update_customer(default_api):
 def test_should_create_and_delete_customer(default_api):
     customer_id = create_customer(default_api, random_email())
     response = default_api.customers.delete(customer_id)
-    assert_response(response, 'http_response')
+    assert_response(response, 'http_metadata')
 
     try:
         default_api.customers.get(customer_id)

--- a/tests/disputes/disputes_four_integration_test.py
+++ b/tests/disputes/disputes_four_integration_test.py
@@ -20,7 +20,7 @@ def test_should_query_disputes(four_api):
 
     response = four_api.disputes.query(query)
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'limit',
                     'total_count',
                     'from',
@@ -45,7 +45,7 @@ def test_should_upload_file(four_api):
 
     file_details = four_api.disputes.get_file_details(response.id)
     assert_response(file_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'filename',
                     'purpose',
@@ -90,7 +90,7 @@ def test_should_test_full_disputes_workflow(four_api):
 
     evidence = four_api.disputes.get_evidence(dispute_id)
     assert_response(evidence,
-                    'http_response',
+                    'http_metadata',
                     'proof_of_delivery_or_service_file',
                     'proof_of_delivery_or_service_text',
                     'invoice_or_receipt_file',

--- a/tests/disputes/disputes_integration_test.py
+++ b/tests/disputes/disputes_integration_test.py
@@ -20,7 +20,7 @@ def test_should_query_disputes(default_api):
 
     response = default_api.disputes.query(query)
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'limit',
                     'total_count',
                     'from',
@@ -45,7 +45,7 @@ def test_should_upload_file(default_api):
 
     file_details = default_api.disputes.get_file_details(response.id)
     assert_response(file_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'filename',
                     'purpose',
@@ -87,11 +87,11 @@ def test_should_test_full_disputes_workflow(default_api):
     dispute_id = query_response.data.id
 
     put_response = default_api.disputes.put_evidence(dispute_id, evidence_request)
-    assert_response(put_response, 'http_response')
+    assert_response(put_response, 'http_metadata')
 
     evidence = default_api.disputes.get_evidence(dispute_id)
     assert_response(evidence,
-                    'http_response',
+                    'http_metadata',
                     'proof_of_delivery_or_service_file',
                     'proof_of_delivery_or_service_text',
                     'invoice_or_receipt_file',

--- a/tests/events/events_integration_test.py
+++ b/tests/events/events_integration_test.py
@@ -63,11 +63,11 @@ def test_should_retrieve_events_by_payment_id_and_retrieve_event_by_id_and_get_n
 
     retry_webhook = default_api.events.retry_webhook(events.data[0].id, webhook.id)
 
-    assert_response(retry_webhook, 'http_response')
+    assert_response(retry_webhook, 'http_metadata')
 
     retry_all_webhooks = default_api.events.retry_all_webhooks(events.data[0].id)
 
-    assert_response(retry_all_webhooks, 'http_response')
+    assert_response(retry_all_webhooks, 'http_metadata')
 
 
 def __events_has_data(response) -> bool:

--- a/tests/forex/forex_four_integration_test.py
+++ b/tests/forex/forex_four_integration_test.py
@@ -14,7 +14,7 @@ def test_should_request_quote(oauth_api):
 
     response = oauth_api.forex.request_quote(quote_request)
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'source_currency',
                     'source_amount',

--- a/tests/instruments/instruments_four_integration_test.py
+++ b/tests/instruments/instruments_four_integration_test.py
@@ -16,7 +16,7 @@ from tests.checkout_test_utils import assert_response, phone, VisaCard, address,
 def test_should_create_and_get_instrument(four_api):
     create_instrument_response = create_token_instrument(four_api)
     assert_response(create_instrument_response,
-                    'http_response',
+                    'http_metadata',
                     'bin',
                     'card_category',
                     'card_type',
@@ -37,7 +37,7 @@ def test_should_create_and_get_instrument(four_api):
     get_instrument_response = four_api.instruments.get(create_instrument_response.id)
 
     assert_response(get_instrument_response,
-                    'http_response',
+                    'http_metadata',
                     'bin',
                     'card_category',
                     'card_type',
@@ -86,7 +86,7 @@ def test_should_create_and_update_instrument(four_api):
     assert get_instrument_response.expiry_month == 12
 
     assert_response(create_instrument_response,
-                    'http_response',
+                    'http_metadata',
                     'scheme',
                     'bin',
                     'card_category',

--- a/tests/instruments/instruments_integration_test.py
+++ b/tests/instruments/instruments_integration_test.py
@@ -12,7 +12,7 @@ from tests.checkout_test_utils import assert_response, phone, VisaCard, address,
 def test_should_create_and_get_instrument(default_api):
     create_instrument_response = create_token_instrument(default_api)
     assert_response(create_instrument_response,
-                    'http_response',
+                    'http_metadata',
                     'bin',
                     'card_category',
                     'card_type',
@@ -33,7 +33,7 @@ def test_should_create_and_get_instrument(default_api):
     get_instrument_response = default_api.instruments.get(create_instrument_response.id)
 
     assert_response(get_instrument_response,
-                    'http_response',
+                    'http_metadata',
                     'bin',
                     'card_category',
                     'card_type',

--- a/tests/marketplace/marketplace_four_payout_schedules_integration_test.py
+++ b/tests/marketplace/marketplace_four_payout_schedules_integration_test.py
@@ -33,13 +33,13 @@ def test_should_update_and_retrieve_weekly_payout_schedules(payout_schedules_api
     payout_schedule = payout_schedules_api.marketplace.update_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq', Currency.USD, schedule_request)
 
-    assert_response(payout_schedule, 'http_response')
-    assert payout_schedule.http_response.status_code == 200
+    assert_response(payout_schedule, 'http_metadata')
+    assert payout_schedule.http_metadata.status_code == 200
 
     retrieve_payout_schedule = payout_schedules_api.marketplace.retrieve_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq')
 
-    assert_response(retrieve_payout_schedule, 'http_response',
+    assert_response(retrieve_payout_schedule, 'http_metadata',
                     'USD',
                     'USD.enabled',
                     'USD.recurrence',
@@ -58,13 +58,13 @@ def test_should_update_and_retrieve_daily_payout_schedules(payout_schedules_api)
     payout_schedule = payout_schedules_api.marketplace.update_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq', Currency.USD, schedule_request)
 
-    assert_response(payout_schedule, 'http_response')
-    assert payout_schedule.http_response.status_code == 200
+    assert_response(payout_schedule, 'http_metadata')
+    assert payout_schedule.http_metadata.status_code == 200
 
     retrieve_payout_schedule = payout_schedules_api.marketplace.retrieve_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq')
 
-    assert_response(retrieve_payout_schedule, 'http_response',
+    assert_response(retrieve_payout_schedule, 'http_metadata',
                     'USD',
                     'USD.enabled',
                     'USD.recurrence',
@@ -83,13 +83,13 @@ def test_should_update_and_retrieve_montly_payout_schedules(payout_schedules_api
     payout_schedule = payout_schedules_api.marketplace.update_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq', Currency.USD, schedule_request)
 
-    assert_response(payout_schedule, 'http_response')
-    assert payout_schedule.http_response.status_code == 200
+    assert_response(payout_schedule, 'http_metadata')
+    assert payout_schedule.http_metadata.status_code == 200
 
     retrieve_payout_schedule = payout_schedules_api.marketplace.retrieve_payout_schedule(
         'ent_sdioy6bajpzxyl3utftdp7legq')
 
-    assert_response(retrieve_payout_schedule, 'http_response',
+    assert_response(retrieve_payout_schedule, 'http_metadata',
                     'USD',
                     'USD.enabled',
                     'USD.recurrence',

--- a/tests/payments/four/capture_payments_four_integration_test.py
+++ b/tests/payments/four/capture_payments_four_integration_test.py
@@ -15,7 +15,7 @@ def test_should_full_capture_card_payment(four_api):
                                  payment_id=payment_response.id,
                                  capture_request=capture_request)
     assert_response(capture_response,
-                    'http_response',
+                    'http_metadata',
                     'reference',
                     'action_id',
                     '_links')
@@ -32,7 +32,7 @@ def test_should_partially_capture_card_payment(four_api):
                                  payment_id=payment_response.id,
                                  capture_request=capture_request)
     assert_response(capture_response,
-                    'http_response',
+                    'http_metadata',
                     'reference',
                     'action_id',
                     '_links')

--- a/tests/payments/four/get_payment_details_four_integration_test.py
+++ b/tests/payments/four/get_payment_details_four_integration_test.py
@@ -12,7 +12,7 @@ def test_should_get_payment_details(four_api):
     payment = retriable(callback=four_api.payments.get_payment_details,
                         payment_id=payment_response.id)
     assert_response(payment,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'requested_on',
                     'amount',

--- a/tests/payments/four/increment_payment_authorizations_four_integration_test.py
+++ b/tests/payments/four/increment_payment_authorizations_four_integration_test.py
@@ -18,7 +18,7 @@ def test_should_increment_payment_authorization(four_api):
 
     void_response = four_api.payments.increment_payment_authorization(payment_response.id, authorization_request)
     assert_response(void_response,
-                    'http_response',
+                    'http_metadata',
                     'amount',
                     'action_id',
                     'currency',

--- a/tests/payments/four/payment_actions_four_integration_test.py
+++ b/tests/payments/four/payment_actions_four_integration_test.py
@@ -10,7 +10,7 @@ def test_should_get_payment_actions(four_api):
     response = retriable(callback=four_api.payments.get_payment_actions,
                          predicate=there_are_two_payment_actions,
                          payment_id=payment_response.id)
-    assert_response(response, 'http_response')
+    assert_response(response, 'http_metadata')
     actions = response.items
     assert type(actions) is list
     assert actions.__len__() > 0

--- a/tests/payments/four/refund_payments_four_integration_test.py
+++ b/tests/payments/four/refund_payments_four_integration_test.py
@@ -19,7 +19,7 @@ def test_should_refund_card_payment(four_api):
                                 refund_request=refund_request)
 
     assert_response(refund_response,
-                    'http_response',
+                    'http_metadata',
                     'reference',
                     'action_id',
                     '_links')
@@ -27,7 +27,7 @@ def test_should_refund_card_payment(four_api):
     payment = retriable(callback=four_api.payments.get_payment_details,
                         payment_id=payment_response.id)
     assert_response(payment,
-                    'http_response',
+                    'http_metadata',
                     'balances.total_authorized',
                     'balances.total_captured',
                     'balances.total_refunded')

--- a/tests/payments/four/request_apm_payments_four_integration_test.py
+++ b/tests/payments/four/request_apm_payments_four_integration_test.py
@@ -32,7 +32,7 @@ def test_should_request_ideal_payment(four_api):
     payment_response = retriable(callback=four_api.payments.request_payment,
                                  payment_request=payment_request)
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'status',
                     '_links',
@@ -42,7 +42,7 @@ def test_should_request_ideal_payment(four_api):
     payment_details = retriable(callback=four_api.payments.get_payment_details,
                                 payment_id=payment_response.id)
     assert_response(payment_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'requested_on',
                     'source',
@@ -64,7 +64,7 @@ def test_should_request_sofort_payment(four_api):
     payment_response = retriable(callback=four_api.payments.request_payment,
                                  payment_request=payment_request)
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'status',
                     '_links',
@@ -74,7 +74,7 @@ def test_should_request_sofort_payment(four_api):
     payment_details = retriable(callback=four_api.payments.get_payment_details,
                                 payment_id=payment_response.id)
     assert_response(payment_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'requested_on',
                     'source',

--- a/tests/payments/four/request_payments_four_integration_test.py
+++ b/tests/payments/four/request_payments_four_integration_test.py
@@ -8,7 +8,7 @@ def test_should_request_card_payment(four_api):
     payment_response = make_card_payment(four_api)
 
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'processed_on',
                     'reference',
@@ -52,7 +52,7 @@ def test_should_request_card_3ds_payment(four_api):
     payment_response = make_3ds_card_payment(four_api, False)
 
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'status',
@@ -68,7 +68,7 @@ def test_should_request_card_3ds_payment_n3d(four_api):
     payment_response = make_3ds_card_payment(four_api, True)
 
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'processed_on',
                     'reference',
@@ -112,7 +112,7 @@ def test_should_request_token_payment(four_api):
     payment_response = make_token_payment(four_api)
 
     assert_response(payment_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'processed_on',
                     'reference',

--- a/tests/payments/four/void_payments_four_integration_test.py
+++ b/tests/payments/four/void_payments_four_integration_test.py
@@ -15,7 +15,7 @@ def test_should_void_card_payment(four_api):
                               payment_id=payment_response.id,
                               void_request=void_request)
     assert_response(void_response,
-                    'http_response',
+                    'http_metadata',
                     'reference',
                     'action_id',
                     '_links')

--- a/tests/payments/hosted/hosted_payments_four_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_four_integration_test.py
@@ -18,7 +18,7 @@ def test_should_create_and_get_hosted_payments_page_details(four_api):
     response = four_api.hosted_payments.create_hosted_payments_page_session(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     '_links',
@@ -28,7 +28,7 @@ def test_should_create_and_get_hosted_payments_page_details(four_api):
     hosted_details = four_api.hosted_payments.get_hosted_payments_page_details(response.id)
 
     assert_response(hosted_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'status',

--- a/tests/payments/hosted/hosted_payments_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_integration_test.py
@@ -14,7 +14,7 @@ def test_should_create_and_get_hosted_payments_page_details(default_api):
     response = default_api.hosted_payments.create_hosted_payments_page_session(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     '_links',
@@ -24,7 +24,7 @@ def test_should_create_and_get_hosted_payments_page_details(default_api):
     hosted_details = default_api.hosted_payments.get_hosted_payments_page_details(response.id)
 
     assert_response(hosted_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'status',

--- a/tests/payments/links/payments_links_four_integration_test.py
+++ b/tests/payments/links/payments_links_four_integration_test.py
@@ -17,7 +17,7 @@ def test_should_create_and_get_payment_link(four_api):
     response = four_api.payments_links.create_payment_link(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'expires_on',
@@ -28,7 +28,7 @@ def test_should_create_and_get_payment_link(four_api):
 
     for warning in response.warnings:
         assert_response(warning,
-                        'http_response',
+                        'http_metadata',
                         'code',
                         'value',
                         'description')
@@ -36,7 +36,7 @@ def test_should_create_and_get_payment_link(four_api):
     hosted_details = four_api.payments_links.get_payment_link(response.id)
 
     assert_response(hosted_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'status',

--- a/tests/payments/links/payments_links_integration_test.py
+++ b/tests/payments/links/payments_links_integration_test.py
@@ -14,7 +14,7 @@ def test_should_create_and_get_payment_link(default_api):
     response = default_api.payments_links.create_payment_link(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'expires_on',
@@ -32,7 +32,7 @@ def test_should_create_and_get_payment_link(default_api):
     hosted_details = default_api.payments_links.get_payment_link(response.id)
 
     assert_response(hosted_details,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'reference',
                     'status',

--- a/tests/risk/risk_four_integration_test.py
+++ b/tests/risk/risk_four_integration_test.py
@@ -111,7 +111,7 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     response = api_client.risk.request_pre_authentication_risk_scan(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'assessment_id',
                     'result',
                     'result.decision',
@@ -151,7 +151,7 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     response = api_client.risk.request_pre_capture_risk_scan(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'assessment_id',
                     'result',
                     'result.decision')

--- a/tests/risk/risk_integration_test.py
+++ b/tests/risk/risk_integration_test.py
@@ -112,7 +112,7 @@ def authentication_assessment_request(api_client: CheckoutApi, request_source: R
     response = api_client.risk.request_pre_authentication_risk_scan(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'assessment_id',
                     'result',
                     'result.decision',
@@ -152,7 +152,7 @@ def pre_capture_assessment_request(api_client: CheckoutApi, request_source: Risk
     response = api_client.risk.request_pre_capture_risk_scan(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'assessment_id',
                     'result',
                     'result.decision',

--- a/tests/tokens/tokens_four_integration_test.py
+++ b/tests/tokens/tokens_four_integration_test.py
@@ -15,7 +15,7 @@ def test_should_create_card_token(four_api):
     response = four_api.tokens.request_card_token(card_token_request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'token',
                     'type',
                     'expires_on',

--- a/tests/tokens/tokens_integration_test.py
+++ b/tests/tokens/tokens_integration_test.py
@@ -15,7 +15,7 @@ def test_should_create_card_token(default_api):
     response = default_api.tokens.request_card_token(request)
 
     assert_response(response,
-                    'http_response',
+                    'http_metadata',
                     'token',
                     'type',
                     'expires_on',

--- a/tests/webhooks/webhooks_integration_test.py
+++ b/tests/webhooks/webhooks_integration_test.py
@@ -76,8 +76,8 @@ def test_full_webhook_operations(default_api):
 
     # Delete webhook
     remove_webhook = default_api.webhooks.remove_webhook(webhook.id)
-    assert_response(remove_webhook, 'http_response')
-    assert 200 == remove_webhook.http_response.status_code
+    assert_response(remove_webhook, 'http_metadata')
+    assert 200 == remove_webhook.http_metadata.status_code
 
 
 def register_webhook(default_api: CheckoutApi, url: str):

--- a/tests/workflows/workflow_integration_test.py
+++ b/tests/workflows/workflow_integration_test.py
@@ -10,7 +10,7 @@ def test__should_create_and_get_workflows(four_api):
     workflow_response = four_api.workflows.get_workflow(workflow.id)
 
     assert_response(workflow_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'name',
                     'active',
@@ -54,7 +54,7 @@ def test__should_create_and_update_workflow(four_api):
     update_workflow_response = four_api.workflows.update_workflow(workflow.id, update_workflow_request)
 
     assert_response(update_workflow_response,
-                    'http_response',
+                    'http_metadata',
                     'name',
                     'active')
 
@@ -70,7 +70,7 @@ def test__should_update_workflow_action(four_api):
     workflow_response = four_api.workflows.get_workflow(workflow.id)
 
     assert_response(workflow_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'name',
                     'active',
@@ -104,7 +104,7 @@ def test__should_update_workflow_condition(four_api):
     workflow_response = four_api.workflows.get_workflow(workflow.id)
 
     assert_response(workflow_response,
-                    'http_response',
+                    'http_metadata',
                     'id',
                     'name',
                     'active',


### PR DESCRIPTION
This commit maps the raw `http_metadata` metadata to a custom `HttpMetadata` class.