### PR TITLE
Remap AccountHolder & MarketplaceAccountHolder

### DIFF
--- a/checkout_sdk/common/common_four.py
+++ b/checkout_sdk/common/common_four.py
@@ -17,16 +17,16 @@ class AccountHolderIdentification:
 
 
 class AccountHolder:
+    type: AccountHolderType
     first_name: str
     last_name: str
-    billing_address: Address
-    phone: Phone
-    type: AccountHolderType
     company_name: str
     tax_id: str
     date_of_birth: str
     country_of_birth: Country
     residential_status: ResidentialStatusType
+    billing_address: Address
+    phone: Phone
     identification: AccountHolderIdentification
     email: str
 

--- a/checkout_sdk/marketplace/marketplace.py
+++ b/checkout_sdk/marketplace/marketplace.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
 from checkout_sdk.common.common import Phone, Address
-from checkout_sdk.common.common_four import AccountHolder
+from checkout_sdk.common.common_four import ResidentialStatusType, AccountHolderIdentification
 from checkout_sdk.common.enums import Currency, InstrumentType, Country
-from checkout_sdk.common.enums_four import AccountType
+from checkout_sdk.common.enums_four import AccountType, AccountHolderType
 
 
 class ContactDetails:
@@ -100,6 +100,21 @@ class BankDetails:
     address: Address
 
 
+class MarketplaceAccountHolder:
+    type: AccountHolderType
+    first_name: str
+    last_name: str
+    company_name: str
+    tax_id: str
+    date_of_birth: DateOfBirth
+    country_of_birth: Country
+    residential_status: ResidentialStatusType
+    billing_address: Address
+    phone: Phone
+    identification: AccountHolderIdentification
+    email: str
+
+
 class MarketplacePaymentInstrument:
     type = InstrumentType.BANK_ACCOUNT
     label: str
@@ -113,7 +128,7 @@ class MarketplacePaymentInstrument:
     currency: Currency
     country: Country
     document: InstrumentDocument
-    account_holder: AccountHolder
+    account_holder: MarketplaceAccountHolder
     bank: BankDetails
 
 


### PR DESCRIPTION
After looking with more details AccountHolder & MarketplaceAccountHolder, we found that it cannot be the same for ABC and NAS, because `date_of_birth` in ABC is a string and NAS is a `DateOfBirth` according to the oficial API reference, for that reason we are going to provide support for both objects in a separate way.