### PR TITLE
 Release Version 3.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: "Bug report"
+about: Create a bug report
+---
+
+<!--- Provide a title with a general summary of the issue -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Environment
+<!--- Include the following details: -->
+* Checkout SDK version:
+* Platform and version:
+* Operating System and version:
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Description
+<!--- Provide a clear and concise description of what the bug is -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Expected behavior
+<!--- Describe what should happen -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Current behavior
+<!--- Describe what happens instead -->
+<!--- Errors, exceptions, stack traces, and relevant logs can be included -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Steps to reproduce
+<!--- If applicable, provide a snippet of code that can be used to reproduce the issue -->
+<!--- Please avoid adding any unrelated code -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Possible solution
+<!--- Feel free to suggest a solution -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+- [ ] I may be able to implement this bug fix
+
+### Additional information
+<!--- Feel free to add any additional information that can help to diagnose and fix the issue -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: "Feature request"
+about: Request a new future or an improvement to an existing feature
+---
+
+<!--- Provide a title with a general summary of the feature  -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Environment
+<!--- Include the following details: -->
+* Checkout SDK version:
+* Platform and version:
+* Operating System and version:
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+### Description
+<!--- Provide a clear and concise description of what can be implemented -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+## Proposed Solution
+<!--- Provide suggestions on how to implement the requested feature (optional) -->
+<!--- Feel free to suggest any alternative solutions or features you've considered -->
+<!--- PLEASE DO NOT SHARE ANY CREDENTIALS -->
+
+- [ ] I may be able to implement this feature

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```
 # Requires Python > 3.6
-pip install checkout-sdk==3.0.0b8
+pip install checkout-sdk==3.0.0
 ```
 
 > **Version 3.0.0 is here!**
@@ -20,7 +20,7 @@ pip install checkout-sdk==3.0.0b8
 > If you have been using this SDK before, you may find the following important changes:
 > * Imports: if you used to import `checkout_sdk.payments.payments` now use `checkout_sdk.payments.payments_previous`
 > * Marketplace module was moved to Accounts module, same for classes and references.
-> * In most cases, IDE can help you determine from where to import, but if you’re still having issues don't hesitate to open a [ticket](https://github.com/checkout/checkout-sdk-python/issues).
+> * In most cases, IDE can help you determine from where to import, but if you’re still having issues don't hesitate to open a [ticket](https://github.com/checkout/checkout-sdk-python/issues/new/choose).
 
 
 ### :rocket: Please check in [GitHub releases](https://github.com/checkout/checkout-sdk-python/releases) for all the versions available.

--- a/checkout_sdk/properties.py
+++ b/checkout_sdk/properties.py
@@ -1,1 +1,1 @@
-VERSION = "3.0.0b8"
+VERSION = "3.0.0"


### PR DESCRIPTION
**Version 3.0.0 is here!**
* We improved the initialization of SDK making it easier to understand the available options.
* Now `NAS` accounts are the default instance for the SDK and `ABC` structure was moved to a `previous` prefixes.
* If you have been using this SDK before, you may find the following important changes:
  * Imports: if you used to import `checkout_sdk.payments.payments` now use `checkout_sdk.payments.payments_previous`
  * Marketplace module was moved to Accounts module, same for classes and references.
  * In most cases, IDE can help you determine from where to import, but if you're still having issues don't hesitate to open a ticket.