### PR TITLE
API Updates

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -7,7 +7,12 @@ on:
 jobs:
   build:
     if: "!contains(github.event.commits[0].message, 'Release')"
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    # python3.6 reached EOL and is no longer being supported on
+    # new versions of hosted runners on GitHub Actions
+    # ubuntu-20.04 is the last version that supported python3.6
+    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -6,7 +6,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    # python3.6 reached EOL and is no longer being supported on
+    # new versions of hosted runners on GitHub Actions
+    # ubuntu-20.04 is the last version that supported python3.6
+    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,12 @@ on:
 jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    # python3.6 reached EOL and is no longer being supported on
+    # new versions of hosted runners on GitHub Actions
+    # ubuntu-20.04 is the last version that supported python3.6
+    # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - id: setup-python

--- a/checkout_sdk/accounts/accounts_client.py
+++ b/checkout_sdk/accounts/accounts_client.py
@@ -25,7 +25,7 @@ class AccountsClient(Client):
                  configuration: CheckoutConfiguration):
         super().__init__(api_client=api_client,
                          configuration=configuration,
-                         authorization_type=AuthorizationType.OAUTH)
+                         authorization_type=AuthorizationType.SECRET_KEY_OR_OAUTH)
         self.__files_client = files_client
 
     def upload_file(self, file_request: FileRequest):

--- a/checkout_sdk/payments/payments.py
+++ b/checkout_sdk/payments/payments.py
@@ -207,6 +207,7 @@ class PaymentRequestTokenSource(PaymentRequestSource):
     token: str
     billing_address: Address
     phone: Phone
+    stored: bool
     store_for_future_use: bool
 
     def __init__(self):
@@ -234,6 +235,8 @@ class PaymentRequestIdSource(PaymentRequestSource):
     id: str
     cvv: str
     payment_method: str
+    stored: bool
+    store_for_future_use: bool
 
     def __init__(self):
         super().__init__(PaymentSourceType.ID)

--- a/checkout_sdk/payments/payments.py
+++ b/checkout_sdk/payments/payments.py
@@ -306,7 +306,9 @@ class PaymentRecipient:
     dob: str
     account_number: str
     zip: str
+    first_name: str
     last_name: str
+    country: Country
 
 
 class Payer:

--- a/checkout_sdk/payments/payments_previous.py
+++ b/checkout_sdk/payments/payments_previous.py
@@ -129,6 +129,8 @@ class RequestIdSource(RequestSource):
     id: str
     cvv: str
     payment_method: str
+    stored: bool
+    store_for_future_use: bool
 
     def __init__(self):
         super().__init__(PaymentSourceType.ID)
@@ -155,6 +157,7 @@ class RequestTokenSource(RequestSource):
     token: str
     billing_address: Address
     phone: Phone
+    stored: bool
     store_for_future_use: bool
 
     def __init__(self):

--- a/checkout_sdk/risk/risk_client.py
+++ b/checkout_sdk/risk/risk_client.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from warnings import warn
+
 from checkout_sdk.api_client import ApiClient
 from checkout_sdk.authorization_type import AuthorizationType
 from checkout_sdk.checkout_configuration import CheckoutConfiguration
@@ -15,6 +17,10 @@ class RiskClient(Client):
         super().__init__(api_client=api_client,
                          configuration=configuration,
                          authorization_type=AuthorizationType.SECRET_KEY)
+        warn(
+            'Risk endpoints are no longer supported officially, This module will be removed in a future release.',
+            DeprecationWarning,
+            stacklevel=2)
 
     def request_pre_authentication_risk_scan(self,
                                              pre_authentication_assessment_request: PreAuthenticationAssessmentRequest):

--- a/checkout_sdk/transfers/transfers_client.py
+++ b/checkout_sdk/transfers/transfers_client.py
@@ -14,7 +14,7 @@ class TransfersClient(Client):
                  configuration: CheckoutConfiguration):
         super().__init__(api_client=api_client,
                          configuration=configuration,
-                         authorization_type=AuthorizationType.OAUTH)
+                         authorization_type=AuthorizationType.SECRET_KEY_OR_OAUTH)
 
     def initiate_transfer_of_funds(self, create_transfer_request: CreateTransferRequest, idempotency_key: str = None):
         return self._api_client.post(self.__TRANSFERS_PATH, self._sdk_authorization(), create_transfer_request,

--- a/tests/checkout_test_utils.py
+++ b/tests/checkout_test_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from checkout_sdk.common.common import Address, Phone, CustomerRequest
 from checkout_sdk.common.enums import Country
 from checkout_sdk.exception import CheckoutException, CheckoutApiException
-from checkout_sdk.payments.payments import Payer
+from checkout_sdk.payments.payments import Payer, PaymentRecipient
 
 NAME = 'Integration Test'
 FIRST_NAME = 'Integration'
@@ -117,3 +117,14 @@ def get_payer():
     payer.name = NAME
     payer.document = '53033315550'
     return payer
+
+
+def get_payment_recipient():
+    recipient = PaymentRecipient()
+    recipient.account_number = '123456789'
+    recipient.dob = '1985-05-18'
+    recipient.first_name = 'IT'
+    recipient.last_name = 'Testing'
+    recipient.zip = '12345'
+    recipient.country = Country.ES
+    return recipient

--- a/tests/payments/hosted/hosted_payments_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_integration_test.py
@@ -5,10 +5,10 @@ import pytest
 from checkout_sdk.common.common import CustomerRequest, Product
 from checkout_sdk.common.enums import Currency, PaymentSourceType
 from checkout_sdk.payments.hosted.hosted_payments import HostedPaymentsSessionRequest
-from checkout_sdk.payments.payments_previous import BillingInformation
 from checkout_sdk.payments.payments import BillingDescriptor, ShippingDetails, ThreeDsRequest, RiskRequest, \
-    PaymentRecipient, ProcessingSettings
-from tests.checkout_test_utils import assert_response, phone, address, random_email
+    ProcessingSettings
+from checkout_sdk.payments.payments_previous import BillingInformation
+from tests.checkout_test_utils import assert_response, phone, address, random_email, get_payment_recipient
 
 
 @pytest.mark.skip(reason='not available')
@@ -59,12 +59,6 @@ def create_hosted_payments_request():
     shipping_details.address = address()
     shipping_details.phone = phone()
 
-    recipient = PaymentRecipient()
-    recipient.account_number = '123456789'
-    recipient.dob = '1985-05-18'
-    recipient.last_name = 'Testing'
-    recipient.zip = '12345'
-
     product = Product()
     product.name = 'Gold Necklace'
     product.quantity = 1
@@ -93,7 +87,7 @@ def create_hosted_payments_request():
     request.customer = customer_request
     request.shipping = shipping_details
     request.billing = billing_information
-    request.recipient = recipient
+    request.recipient = get_payment_recipient()
     request.processing = processing_settings
     request.products = [product]
     request.risk = risk_request

--- a/tests/payments/hosted/hosted_payments_previous_integration_test.py
+++ b/tests/payments/hosted/hosted_payments_previous_integration_test.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 from checkout_sdk.common.common import CustomerRequest, Product
 from checkout_sdk.common.enums import Currency, PaymentSourceType
 from checkout_sdk.payments.hosted.hosted_payments import HostedPaymentsSessionRequest
+from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, ProcessingSettings
 from checkout_sdk.payments.payments_previous import BillingInformation
-from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, PaymentRecipient, \
-    ProcessingSettings
-from tests.checkout_test_utils import assert_response, phone, address, random_email
+from tests.checkout_test_utils import assert_response, phone, address, random_email, get_payment_recipient
 
 
 def test_should_create_and_get_hosted_payments_page_details(previous_api):
@@ -56,12 +55,6 @@ def create_hosted_payments_request():
     shipping_details.address = address()
     shipping_details.phone = phone()
 
-    recipient = PaymentRecipient()
-    recipient.account_number = '123456789'
-    recipient.dob = '1985-05-18'
-    recipient.last_name = 'Testing'
-    recipient.zip = '12345'
-
     product = Product()
     product.name = 'Gold Necklace'
     product.quantity = 1
@@ -85,7 +78,7 @@ def create_hosted_payments_request():
     request.customer = customer_request
     request.shipping = shipping_details
     request.billing = billing_information
-    request.recipient = recipient
+    request.recipient = get_payment_recipient()
     request.processing = processing_settings
     request.products = [product]
     request.risk = risk_request

--- a/tests/payments/links/payments_links_integration_test.py
+++ b/tests/payments/links/payments_links_integration_test.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 from checkout_sdk.common.common import CustomerRequest, Product, Commission, AmountAllocations
 from checkout_sdk.common.enums import Currency, PaymentSourceType
 from checkout_sdk.payments.links.payments_links import PaymentLinkRequest
-from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, PaymentRecipient, \
-    ProcessingSettings
+from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, ProcessingSettings
 from checkout_sdk.payments.payments_previous import BillingInformation
-from tests.checkout_test_utils import assert_response, phone, address, random_email, new_uuid
+from tests.checkout_test_utils import assert_response, phone, address, random_email, new_uuid, get_payment_recipient
 
 
 def test_should_create_and_get_payment_link(default_api):
@@ -71,12 +70,6 @@ def create_payment_link_request():
     shipping_details.address = address()
     shipping_details.phone = phone()
 
-    recipient = PaymentRecipient()
-    recipient.account_number = '123456789'
-    recipient.dob = '1985-05-18'
-    recipient.last_name = 'Testing'
-    recipient.zip = '12345'
-
     product = Product()
     product.name = 'Gold Necklace'
     product.quantity = 1
@@ -100,7 +93,7 @@ def create_payment_link_request():
     request.customer = customer_request
     request.shipping = shipping_details
     request.billing = billing_information
-    request.recipient = recipient
+    request.recipient = get_payment_recipient()
     request.processing = processing_settings
     request.products = [product]
     request.risk = risk_request

--- a/tests/payments/links/payments_links_previous_integration_test.py
+++ b/tests/payments/links/payments_links_previous_integration_test.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 from checkout_sdk.common.common import CustomerRequest, Product
 from checkout_sdk.common.enums import Currency, PaymentSourceType
 from checkout_sdk.payments.links.payments_links import PaymentLinkRequest
+from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, ProcessingSettings
 from checkout_sdk.payments.payments_previous import BillingInformation
-from checkout_sdk.payments.payments import ShippingDetails, ThreeDsRequest, RiskRequest, PaymentRecipient, \
-    ProcessingSettings
-from tests.checkout_test_utils import assert_response, phone, address, random_email
+from tests.checkout_test_utils import assert_response, phone, address, random_email, get_payment_recipient
 
 
 def test_should_create_and_get_payment_link(previous_api):
@@ -64,12 +63,6 @@ def create_payment_link_request():
     shipping_details.address = address()
     shipping_details.phone = phone()
 
-    recipient = PaymentRecipient()
-    recipient.account_number = '123456789'
-    recipient.dob = '1985-05-18'
-    recipient.last_name = 'Testing'
-    recipient.zip = '12345'
-
     product = Product()
     product.name = 'Gold Necklace'
     product.quantity = 1
@@ -93,7 +86,7 @@ def create_payment_link_request():
     request.customer = customer_request
     request.shipping = shipping_details
     request.billing = billing_information
-    request.recipient = recipient
+    request.recipient = get_payment_recipient()
     request.processing = processing_settings
     request.products = [product]
     request.risk = risk_request

--- a/tests/sessions/request_and_get_sessions_integration_test.py
+++ b/tests/sessions/request_and_get_sessions_integration_test.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pytest
+
 from checkout_sdk.common.enums import ChallengeIndicator
 from checkout_sdk.checkout_api import CheckoutApi
 from checkout_sdk.sessions.sessions import Category, TransactionType
@@ -22,6 +24,7 @@ def test_request_and_get_card_session_browser_session(oauth_api: CheckoutApi):
     assert_response(oauth_api.sessions.get_session_details(session_id, session_secret), 'id')
 
 
+@pytest.mark.skip(reason='unstable')
 def test_request_and_get_card_session_app_session(oauth_api: CheckoutApi):
     browser_session = get_app_session()
     session_request = get_non_hosted_session(browser_session, Category.PAYMENT,


### PR DESCRIPTION
Fix CI for Python 3.6 as reached EOL which is no longer supported for new versions
Added mandatory fields for MIT/CIT payments sources (CS1/CS2)
Restore `first_name` and `country` fields from PaymentRecipient schema
Support Secret Key for Accounts & Transfers (CS2)
Deprecated Risk client (CS1/CS2)