### PR TITLE
Implement retrieve files endpoint in Platforms API

### DIFF
--- a/checkout_sdk/accounts/accounts.py
+++ b/checkout_sdk/accounts/accounts.py
@@ -147,6 +147,10 @@ class OnboardEntityRequest:
     individual: Individual
 
 
+class PlatformsFileRequest:
+    purpose: str
+    entity_id: str
+
 class InstrumentDocument:
     type: str
     file_id: str

--- a/checkout_sdk/accounts/accounts_client.py
+++ b/checkout_sdk/accounts/accounts_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from warnings import warn
 
 from checkout_sdk.accounts.accounts import OnboardEntityRequest, UpdateScheduleRequest, AccountsPaymentInstrument, \
-    PaymentInstrumentRequest, PaymentInstrumentsQuery, UpdatePaymentInstrumentRequest
+    PaymentInstrumentRequest, PaymentInstrumentsQuery, UpdatePaymentInstrumentRequest, PlatformsFileRequest
 from checkout_sdk.api_client import ApiClient
 from checkout_sdk.authorization_type import AuthorizationType
 from checkout_sdk.checkout_configuration import CheckoutConfiguration
@@ -19,6 +19,7 @@ class AccountsClient(Client):
     __FILES_PATH = 'files'
     __PAYOUT_SCHEDULES_PATH = 'payout-schedules'
     __PAYMENT_INSTRUMENTS_PATH = 'payment-instruments'
+    __PLATFORMS_FILES_PATH = 'platforms-files'
 
     def __init__(self, api_client: ApiClient,
                  files_client: ApiClient,
@@ -29,6 +30,8 @@ class AccountsClient(Client):
         self.__files_client = files_client
 
     def upload_file(self, file_request: FileRequest):
+        warn('This endpoint is no longer supported officially, please check the documentation.', DeprecationWarning,
+             stacklevel=2)
         return self.__files_client.submit_file(
             self.__FILES_PATH,
             self._sdk_authorization(),
@@ -41,13 +44,6 @@ class AccountsClient(Client):
             self._sdk_authorization(),
             onboard_entity_request)
 
-    def retrieve_payment_instrument_details(self, entity_id: str, payment_instrument_id: str):
-        return self._api_client.get(
-            self.build_path(self.__ACCOUNTS_PATH, self.__ENTITIES_PATH, entity_id, self.__PAYMENT_INSTRUMENTS_PATH,
-                            payment_instrument_id),
-            self._sdk_authorization()
-        )
-
     def get_entity(self, entity_id: str):
         return self._api_client.get(
             self.build_path(self.__ACCOUNTS_PATH, self.__ENTITIES_PATH, entity_id),
@@ -58,6 +54,17 @@ class AccountsClient(Client):
             self.build_path(self.__ACCOUNTS_PATH, self.__ENTITIES_PATH, entity_id),
             self._sdk_authorization(),
             onboard_entity_request)
+
+    def update_a_file(self, file_request: PlatformsFileRequest):
+        return self._api_client.post(
+            self.build_path(self.__PLATFORMS_FILES_PATH),
+            self._sdk_authorization(),
+            file_request)
+
+    def retrieve_a_file(self, file_id: str):
+        return self._api_client.get(
+            self.build_path(self.__PLATFORMS_FILES_PATH, file_id),
+            self._sdk_authorization())
 
     def create_payment_instrument(self, entity_id: str, accounts_payment_instrument: AccountsPaymentInstrument):
         warn('Deprecated use add_payment_instrument instead', DeprecationWarning,
@@ -74,6 +81,12 @@ class AccountsClient(Client):
             payment_instrument_request
         )
 
+    def retrieve_payment_instrument_details(self, entity_id: str, payment_instrument_id: str):
+        return self._api_client.get(
+            self.build_path(self.__ACCOUNTS_PATH, self.__ENTITIES_PATH, entity_id, self.__PAYMENT_INSTRUMENTS_PATH,
+                            payment_instrument_id),
+            self._sdk_authorization()
+        )
     def update_payment_instrument(self,
                                   entity_id: str,
                                   instrument_id: str,

--- a/tests/accounts/accounts_client_test.py
+++ b/tests/accounts/accounts_client_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from checkout_sdk.accounts.accounts import OnboardEntityRequest, AccountsPaymentInstrument, UpdateScheduleRequest, \
-    PaymentInstrumentRequest, PaymentInstrumentsQuery, UpdatePaymentInstrumentRequest
+    PaymentInstrumentRequest, PaymentInstrumentsQuery, UpdatePaymentInstrumentRequest, PlatformsFileRequest
 from checkout_sdk.accounts.accounts_client import AccountsClient
 from checkout_sdk.common.enums import Currency
 from checkout_sdk.files.files import FileRequest
@@ -28,6 +28,14 @@ class TestAccountsClient:
         mocker.patch('checkout_sdk.api_client.ApiClient.put', return_value='response')
         assert client.update_entity('entity_id', OnboardEntityRequest()) == 'response'
 
+    def test_should_update_a_file(self, mocker, client: AccountsClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.update_a_file(PlatformsFileRequest()) == 'response'
+
+    def test_should_retrieve_a_file(self, mocker, client: AccountsClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.retrieve_a_file('file_id') == 'response'
+
     def test_should_create_payment_instrument_deprecated(self, mocker, client: AccountsClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
         assert client.create_payment_instrument('entity_id', AccountsPaymentInstrument()) == 'response'
@@ -49,6 +57,7 @@ class TestAccountsClient:
         mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
         assert client.retrieve_payment_instrument_details('entity_id', 'payment_instrument_id') == 'response'
 
+    @pytest.mark.skip(reason='obsolete')
     def test_should_upload_file(self, mocker, client: AccountsClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.submit_file', return_value='response')
         assert client.upload_file(FileRequest()) == 'response'


### PR DESCRIPTION
## Implement retrieve files endpoint in Platforms API
Add:
- Upload A File endpoint
- Retrieve A File endpoint

![image](https://user-images.githubusercontent.com/2817124/219415592-1d43eb47-09f4-42c4-bc21-b2d4cf8c8930.png)

Labeled as obsolete:
- SubmitFile method

## API reference
- https://api-reference.checkout.com/#operation/uploadAFile
- https://api-reference.checkout.com/#operation/retrieveAFile

### Notice: `PUT` not implemented
https://www.checkout.com/docs/platforms/onboarding/api/full/upload-a-file#Types_of_identification_and_requirements_1