### PR TITLE
Adds support for Cards operations [Issuing] (CS2)

### DIFF
--- a/checkout_sdk/issuing/cards.py
+++ b/checkout_sdk/issuing/cards.py
@@ -1,0 +1,99 @@
+from enum import Enum
+
+from checkout_sdk.common.common import Address, Phone
+
+
+class CardType(str, Enum):
+    PHYSICAL = 'physical'
+    VIRTUAL = 'virtual'
+
+
+class LifetimeUnit(str, Enum):
+    MONTHS = 'Months'
+    YEARS = 'Years'
+
+
+class RevokeReason(str, Enum):
+    EXPIRED = 'expired'
+    REPORTED_LOST = 'reported_lost'
+    REPORTED_STOLEN = 'reported_stolen'
+
+
+class SuspendReason(str, Enum):
+    SUSPECTED_LOST = 'suspected_lost'
+    SUSPECTED_STOLEN = 'suspected_stolen'
+
+
+class CardLifetime:
+    unit: LifetimeUnit
+    value: int
+
+
+class ShippingInstructions:
+    recipient_address: str
+    shipping_address: Address
+    additional_comment: str
+
+
+class CardRequest:
+    type: CardType
+    cardholder_id: str
+    lifetime: CardLifetime
+    reference: str
+    card_product_id: str
+    display_name: str
+    activate_card: bool
+
+    def __init__(self, type_p: CardType):
+        self.type = type_p
+
+
+class PhysicalCardRequest(CardRequest):
+    shipping_instructions: ShippingInstructions
+
+    def __init__(self):
+        super().__init__(CardType.PHYSICAL)
+
+
+class VirtualCardRequest(CardRequest):
+    is_single_use: bool
+
+    def __init__(self):
+        super().__init__(CardType.VIRTUAL)
+
+
+class SecurityPair:
+    question: str
+    answer: str
+
+
+class ThreeDsEnrollmentRequest:
+    locale: str
+    phone_number: Phone
+
+
+class SecurityQuestionEnrollmentRequest(ThreeDsEnrollmentRequest):
+    security_pair: SecurityPair
+
+
+class PasswordEnrollmentRequest(ThreeDsEnrollmentRequest):
+    password: str
+
+
+class UpdateThreeDsEnrollmentRequest:
+    security_pair: SecurityPair
+    password: str
+    locale: str
+    phone_number: Phone
+
+
+class CardCredentialsQuery:
+    credentials: str
+
+
+class RevokeRequest:
+    reason: RevokeReason
+
+
+class SuspendRequest:
+    reason: SuspendReason

--- a/checkout_sdk/issuing/issuing_client.py
+++ b/checkout_sdk/issuing/issuing_client.py
@@ -5,12 +5,19 @@ from checkout_sdk.authorization_type import AuthorizationType
 from checkout_sdk.checkout_configuration import CheckoutConfiguration
 from checkout_sdk.client import Client
 from checkout_sdk.issuing.cardholders import CardholderRequest
+from checkout_sdk.issuing.cards import CardRequest, ThreeDsEnrollmentRequest, UpdateThreeDsEnrollmentRequest, \
+    CardCredentialsQuery, RevokeRequest, SuspendRequest
 
 
 class IssuingClient(Client):
     __ISSUING = 'issuing'
     __CARDHOLDERS = 'cardholders'
     __CARDS = 'cards'
+    __THREE_DS = '3ds-enrollment'
+    __ACTIVATE = 'activate'
+    __CREDENTIALS = 'credentials'
+    __REVOKE = 'revoke'
+    __SUSPEND = 'suspend'
 
     def __init__(self, api_client: ApiClient, configuration: CheckoutConfiguration):
         super().__init__(api_client=api_client,
@@ -29,3 +36,45 @@ class IssuingClient(Client):
     def get_cardholder_cards(self, cardholder_id: str):
         return self._api_client.get(self.build_path(self.__ISSUING, self.__CARDHOLDERS, cardholder_id, self.__CARDS),
                                     self._sdk_authorization())
+
+    def create_card(self, card_request: CardRequest):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS),
+                                     self._sdk_authorization(),
+                                     card_request)
+
+    def get_card_details(self, card_id: str):
+        return self._api_client.get(self.build_path(self.__ISSUING, self.__CARDS, card_id),
+                                    self._sdk_authorization())
+
+    def enroll_three_ds(self, card_id: str, three_ds_enrollment_request: ThreeDsEnrollmentRequest):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__THREE_DS),
+                                     self._sdk_authorization(),
+                                     three_ds_enrollment_request)
+
+    def update_three_ds_enrollment(self, card_id: str, update_three_ds_enrollment: UpdateThreeDsEnrollmentRequest):
+        return self._api_client.patch(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__THREE_DS),
+                                      self._sdk_authorization(),
+                                      update_three_ds_enrollment)
+
+    def get_three_ds_details(self, card_id: str):
+        return self._api_client.get(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__THREE_DS),
+                                    self._sdk_authorization())
+
+    def activate_card(self, card_id: str):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__ACTIVATE),
+                                     self._sdk_authorization())
+
+    def get_card_credentials(self, card_id: str, card_credentials_query: CardCredentialsQuery):
+        return self._api_client.get(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__CREDENTIALS),
+                                    self._sdk_authorization(),
+                                    card_credentials_query)
+
+    def revoke_card(self, card_id: str, revoke_request: RevokeRequest):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__REVOKE),
+                                     self._sdk_authorization(),
+                                     revoke_request)
+
+    def suspend_card(self, card_id: str, suspend_request: SuspendRequest):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__SUSPEND),
+                                     self._sdk_authorization(),
+                                     suspend_request)

--- a/tests/issuing/cards_issuing_integration_test.py
+++ b/tests/issuing/cards_issuing_integration_test.py
@@ -1,0 +1,142 @@
+import pytest
+
+from checkout_sdk.issuing.cards import PasswordEnrollmentRequest, SecurityPair, UpdateThreeDsEnrollmentRequest, \
+    CardCredentialsQuery, RevokeRequest, RevokeReason, SuspendRequest, SuspendReason
+from tests.checkout_test_utils import assert_response, phone
+
+
+@pytest.mark.skip("Avoid creating cards all the time")
+@pytest.mark.usefixtures("card")
+class TestCardsIssuing:
+    def test_should_create_card(self, card):
+        assert_response(card,
+                        'id',
+                        'display_name',
+                        'last_four',
+                        'expiry_month',
+                        'expiry_year',
+                        'billing_currency',
+                        'issuing_country',
+                        'reference')
+
+        assert card.display_name == 'JOHN KENNEDY'
+        assert card.reference == 'X-123456-N11'
+
+    def test_should_get_card_details(self, issuing_checkout_api, cardholder, card):
+        response = issuing_checkout_api.issuing.get_card_details(card.id)
+
+        assert_response(response,
+                        'id',
+                        'cardholder_id',
+                        'card_product_id',
+                        'display_name',
+                        'last_four',
+                        'expiry_month',
+                        'expiry_year',
+                        'billing_currency',
+                        'issuing_country',
+                        'reference',
+                        'status',
+                        'type')
+
+        assert response.id == card.id
+        assert response.cardholder_id == cardholder.id
+        assert response.card_product_id == 'pro_3fn6pv2ikshurn36dbd3iysyha'
+        assert response.reference == 'X-123456-N11'
+
+    def test_should_enroll_into_three_ds(self, issuing_checkout_api, card):
+        request = PasswordEnrollmentRequest()
+        request.password = 'Xtui43FvfiZ'
+        request.locale = 'en-US'
+        request.phone_number = phone()
+
+        response = issuing_checkout_api.issuing.enroll_three_ds(card.id, request)
+
+        assert_response(response)
+
+        assert response.http_metadata.status_code == 202
+
+    def test_should_update_three_ds_enrollment(self, issuing_checkout_api, card):
+        security_pair = SecurityPair()
+        security_pair.question = 'Who are you?'
+        security_pair.answer = 'Bond. James Bond.'
+
+        request = UpdateThreeDsEnrollmentRequest()
+        request.password = 'Xtui43FvfiZ'
+        request.security_pair = security_pair
+        request.locale = 'en-US'
+        request.phone_number = phone()
+
+        response = issuing_checkout_api.issuing.update_three_ds_enrollment(card.id, request)
+
+        assert_response(response)
+
+        assert response.http_metadata.status_code == 202
+
+    def test_should_get_three_ds_details(self, issuing_checkout_api, card):
+        response = issuing_checkout_api.issuing.get_three_ds_details(card.id)
+
+        assert_response(response,
+                        'locale',
+                        'phone_number')
+
+    def test_should_activate_card(self, issuing_checkout_api, card):
+        response = issuing_checkout_api.issuing.activate_card(card.id)
+
+        assert_response(response)
+        assert response.http_metadata.status_code == 200
+
+        card_response = issuing_checkout_api.issuing.get_card_details(card.id)
+
+        assert_response(card_response,
+                        'id',
+                        'status')
+
+        assert card_response.id == card.id
+        assert card_response.status == 'active'
+
+    def test_get_card_credentials(self, issuing_checkout_api, card):
+        query = CardCredentialsQuery()
+        query.credentials = 'number, cvc2'
+
+        response = issuing_checkout_api.issuing.get_card_credentials(card.id, query)
+
+        assert_response(response,
+                        'number',
+                        'cvc2')
+
+    def test_should_revoke_card(self, issuing_checkout_api, active_card):
+        request = RevokeRequest()
+        request.reason = RevokeReason.REPORTED_STOLEN
+
+        response = issuing_checkout_api.issuing.revoke_card(active_card.id, request)
+
+        assert_response(response)
+        assert response.http_metadata.status_code == 200
+
+        card_response = issuing_checkout_api.issuing.get_card_details(active_card.id)
+
+        assert_response(card_response,
+                        'id',
+                        'status')
+
+        assert card_response.id == active_card.id
+        assert card_response.status == 'revoked'
+
+    def test_should_suspend_card(self, issuing_checkout_api, active_card):
+        request = SuspendRequest()
+        request.reason = SuspendReason.SUSPECTED_STOLEN
+
+        response = issuing_checkout_api.issuing.suspend_card(active_card.id, request)
+
+        assert_response(response)
+        assert response.http_metadata.status_code == 200
+
+        card_response = issuing_checkout_api.issuing.get_card_details(active_card.id)
+
+        assert_response(card_response,
+                        'id',
+                        'status')
+
+        assert card_response.id == active_card.id
+        assert card_response.status == 'suspended'

--- a/tests/issuing/conftest.py
+++ b/tests/issuing/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from checkout_sdk import CheckoutSdk
 from checkout_sdk.common.enums import DocumentType
 from checkout_sdk.issuing.cardholders import CardholderRequest, CardholderDocument, CardholderType
+from checkout_sdk.issuing.cards import CardLifetime, LifetimeUnit, VirtualCardRequest
 from checkout_sdk.oauth_scopes import OAuthScopes
 from tests.checkout_test_utils import phone, address, assert_response
 
@@ -47,3 +48,41 @@ def cardholder(issuing_checkout_api):
     assert_response(cardholder, 'id')
 
     return cardholder
+
+
+@pytest.fixture(scope='class')
+def card(issuing_checkout_api, cardholder):
+    request = get_card_request(cardholder)
+    request.activate_card = False
+
+    card = issuing_checkout_api.issuing.create_card(request)
+
+    assert_response(card, 'id')
+    return card
+
+
+@pytest.fixture()
+def active_card(issuing_checkout_api, cardholder):
+    request = get_card_request(cardholder)
+    request.activate_card = True
+
+    card = issuing_checkout_api.issuing.create_card(request)
+
+    assert_response(card, 'id')
+    return card
+
+
+def get_card_request(cardholder):
+    lifetime = CardLifetime()
+    lifetime.unit = LifetimeUnit.MONTHS
+    lifetime.value = 6
+
+    request = VirtualCardRequest()
+    request.cardholder_id = cardholder.id
+    request.card_product_id = 'pro_3fn6pv2ikshurn36dbd3iysyha'
+    request.lifetime = lifetime
+    request.reference = 'X-123456-N11'
+    request.display_name = 'John Kennedy'
+    request.is_single_use = False
+
+    return request

--- a/tests/issuing/issuing_client_test.py
+++ b/tests/issuing/issuing_client_test.py
@@ -1,6 +1,8 @@
 import pytest
 
 from checkout_sdk.issuing.cardholders import CardholderRequest
+from checkout_sdk.issuing.cards import PhysicalCardRequest, PasswordEnrollmentRequest, UpdateThreeDsEnrollmentRequest, \
+    CardCredentialsQuery, RevokeRequest, SuspendRequest
 from checkout_sdk.issuing.issuing_client import IssuingClient
 
 
@@ -22,3 +24,39 @@ class TestIssuingClient:
     def test_should_get_cardholder_cards(self, mocker, client: IssuingClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
         assert client.get_cardholder_cards('cardholder_id') == 'response'
+
+    def test_should_create_card(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.create_card(PhysicalCardRequest()) == 'response'
+
+    def test_should_get_card_details(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.get_card_details('card_id') == 'response'
+
+    def test_should_enroll_three_ds(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.enroll_three_ds('card_id', PasswordEnrollmentRequest()) == 'response'
+
+    def test_should_update_three_ds_enrollment(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.patch', return_value='response')
+        assert client.update_three_ds_enrollment('card_id', UpdateThreeDsEnrollmentRequest()) == 'response'
+
+    def test_should_get_three_ds_details(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.get_three_ds_details('card_id') == 'response'
+
+    def test_should_activate_card(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.activate_card('card_id') == 'response'
+
+    def test_should_get_card_credentials(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.get_card_credentials('card_id', CardCredentialsQuery()) == 'response'
+
+    def test_should_revoke_card(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.revoke_card('card_id', RevokeRequest()) == 'response'
+
+    def test_should_suspend_card(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.suspend_card('card_id', SuspendRequest()) == 'response'


### PR DESCRIPTION
### Changes
* Adds support for `create_card`
* Adds support for `get_card_details`
* Adds support for `enroll_three_ds`
* Adds support for `update_three_ds_enrollment`
* Adds support for `get_three_ds_details`
* Adds support for `activate_card`
* Adds support for `get_card_credentials`
* Adds support for `revoke_card`
* Adds support for `suspend_card`

### Related PRs
#127 

### API Reference
https://api-reference.checkout.com/#tag/Cards