### PR TITLE
Adds support for Card Controls operations [Issuing] (CS2)

### DIFF
--- a/checkout_sdk/issuing/controls.py
+++ b/checkout_sdk/issuing/controls.py
@@ -1,0 +1,66 @@
+from enum import Enum
+
+
+class ControlType(str, Enum):
+    VELOCITY_LIMIT = 'velocity_limit'
+    MCC_LIMIT = 'mcc_limit'
+
+
+class VelocityWindowType(str, Enum):
+    DAILY = 'daily'
+    WEEKLY = 'weekly'
+    MONTHLY = 'monthly'
+    ALL_TIME = 'all_time'
+
+
+class MccLimitType(str, Enum):
+    ALLOW = 'allow'
+    BLOCK = 'block'
+
+
+class VelocityWindow:
+    type: VelocityWindowType
+
+
+class VelocityLimit:
+    amount_limit: int
+    velocity_window: VelocityWindow
+    mcc_list: list # str
+
+
+class MccLimit:
+    type: MccLimitType
+    mcc_list: list # str
+
+
+class CardControlRequest:
+    description: str
+    control_type: ControlType
+    target_id: str
+
+    def __init__(self, control_type: ControlType):
+        self.control_type = control_type
+
+
+class VelocityControlRequest(CardControlRequest):
+    velocity_limit: VelocityLimit
+
+    def __init__(self):
+        super().__init__(ControlType.VELOCITY_LIMIT)
+
+
+class MccControlRequest(CardControlRequest):
+    mcc_limit: MccLimit
+
+    def __init__(self):
+        super().__init__(ControlType.MCC_LIMIT)
+
+
+class CardControlsQuery:
+    target_id: str
+
+
+class UpdateCardControlRequest:
+    description: str
+    velocity_limit: VelocityLimit
+    mcc_limit: MccLimit

--- a/checkout_sdk/issuing/issuing_client.py
+++ b/checkout_sdk/issuing/issuing_client.py
@@ -7,6 +7,7 @@ from checkout_sdk.client import Client
 from checkout_sdk.issuing.cardholders import CardholderRequest
 from checkout_sdk.issuing.cards import CardRequest, ThreeDsEnrollmentRequest, UpdateThreeDsEnrollmentRequest, \
     CardCredentialsQuery, RevokeRequest, SuspendRequest
+from checkout_sdk.issuing.controls import CardControlRequest, CardControlsQuery, UpdateCardControlRequest
 
 
 class IssuingClient(Client):
@@ -18,6 +19,7 @@ class IssuingClient(Client):
     __CREDENTIALS = 'credentials'
     __REVOKE = 'revoke'
     __SUSPEND = 'suspend'
+    __CONTROLS = 'controls'
 
     def __init__(self, api_client: ApiClient, configuration: CheckoutConfiguration):
         super().__init__(api_client=api_client,
@@ -78,3 +80,26 @@ class IssuingClient(Client):
         return self._api_client.post(self.build_path(self.__ISSUING, self.__CARDS, card_id, self.__SUSPEND),
                                      self._sdk_authorization(),
                                      suspend_request)
+
+    def create_control(self, control_request: CardControlRequest):
+        return self._api_client.post(self.build_path(self.__ISSUING, self.__CONTROLS),
+                                     self._sdk_authorization(),
+                                     control_request)
+
+    def get_card_controls(self, query: CardControlsQuery):
+        return self._api_client.get(self.build_path(self.__ISSUING, self.__CONTROLS),
+                                    self._sdk_authorization(),
+                                    query)
+
+    def get_card_control_details(self, control_id: str):
+        return self._api_client.get(self.build_path(self.__ISSUING, self.__CONTROLS, control_id),
+                                    self._sdk_authorization())
+
+    def update_card_control(self, control_id: str, update_request: UpdateCardControlRequest):
+        return self._api_client.put(self.build_path(self.__ISSUING, self.__CONTROLS, control_id),
+                                    self._sdk_authorization(),
+                                    update_request)
+
+    def remove_control(self, control_id: str):
+        return self._api_client.delete(self.build_path(self.__ISSUING, self.__CONTROLS, control_id),
+                                       self._sdk_authorization())

--- a/tests/issuing/conftest.py
+++ b/tests/issuing/conftest.py
@@ -5,6 +5,7 @@ from checkout_sdk import CheckoutSdk
 from checkout_sdk.common.enums import DocumentType
 from checkout_sdk.issuing.cardholders import CardholderRequest, CardholderDocument, CardholderType
 from checkout_sdk.issuing.cards import CardLifetime, LifetimeUnit, VirtualCardRequest
+from checkout_sdk.issuing.controls import VelocityControlRequest, VelocityLimit, VelocityWindow, VelocityWindowType
 from checkout_sdk.oauth_scopes import OAuthScopes
 from tests.checkout_test_utils import phone, address, assert_response
 
@@ -46,7 +47,6 @@ def cardholder(issuing_checkout_api):
     cardholder = issuing_checkout_api.issuing.create_cardholder(request)
 
     assert_response(cardholder, 'id')
-
     return cardholder
 
 
@@ -70,6 +70,26 @@ def active_card(issuing_checkout_api, cardholder):
 
     assert_response(card, 'id')
     return card
+
+
+@pytest.fixture(scope='class')
+def control(issuing_checkout_api, card):
+    window = VelocityWindow()
+    window.type = VelocityWindowType.WEEKLY
+
+    limit = VelocityLimit()
+    limit.amount_limit = 500
+    limit.velocity_window = window
+
+    request = VelocityControlRequest()
+    request.description = 'Max spend of 500€ per week for restaurants'
+    request.target_id = card.id
+    request.velocity_limit = limit
+
+    control = issuing_checkout_api.issuing.create_control(request)
+
+    assert_response(control, 'id')
+    return control
 
 
 def get_card_request(cardholder):

--- a/tests/issuing/controls_issuing_integration_test.py
+++ b/tests/issuing/controls_issuing_integration_test.py
@@ -1,0 +1,80 @@
+import pytest
+
+from checkout_sdk.issuing.controls import ControlType, CardControlsQuery, VelocityWindowType, UpdateCardControlRequest, \
+    VelocityWindow, VelocityLimit
+from tests.checkout_test_utils import assert_response
+
+
+@pytest.mark.skip("Avoid creating cards all the time")
+class TestControlsIssuing:
+    def test_should_create_card(self, issuing_checkout_api, card, control):
+        assert_response(control,
+                        'id',
+                        'description',
+                        'control_type',
+                        'target_id')
+
+        assert control.target_id == card.id
+        assert control.control_type == ControlType.VELOCITY_LIMIT
+
+    def test_should_get_card_controls(self, issuing_checkout_api, card):
+        query = CardControlsQuery()
+        query.target_id = card.id
+
+        response = issuing_checkout_api.issuing.get_card_controls(query)
+
+        assert_response(response,
+                        'controls')
+
+        for control in response.controls:
+            assert control.target_id == card.id
+
+    def test_should_get_control_details(self, issuing_checkout_api, control):
+        response = issuing_checkout_api.issuing.get_card_control_details(control.id)
+
+        assert_response(response,
+                        'id',
+                        'description',
+                        'control_type',
+                        'target_id',
+                        'velocity_limit')
+
+        assert response.id == control.id
+        assert response.target_id == control.target_id
+        assert response.control_type == ControlType.VELOCITY_LIMIT
+        assert response.velocity_limit.amount_limit == 500
+        assert response.velocity_limit.velocity_window.type == VelocityWindowType.WEEKLY
+
+    def test_should_update_card_controls(self, issuing_checkout_api, control):
+        window = VelocityWindow()
+        window.type = VelocityWindowType.MONTHLY
+
+        limit = VelocityLimit()
+        limit.amount_limit = 1000
+        limit.velocity_window = window
+
+        request = UpdateCardControlRequest()
+        request.description = 'Max spend of 100€ per month for restaurants'
+        request.velocity_limit = limit
+
+        response = issuing_checkout_api.issuing.update_card_control(control.id, request)
+
+        assert_response(response,
+                        'id',
+                        'description',
+                        'control_type',
+                        'target_id',
+                        'velocity_limit')
+
+        assert response.id == control.id
+        assert response.target_id == control.target_id
+        assert response.control_type == ControlType.VELOCITY_LIMIT
+        assert response.velocity_limit.amount_limit == 1000
+        assert response.velocity_limit.velocity_window.type == VelocityWindowType.MONTHLY
+
+    def test_should_remove_control(self, issuing_checkout_api, control):
+        response = issuing_checkout_api.issuing.remove_control(control.id)
+
+        assert_response(response, 'id')
+        assert response.http_metadata.status_code == 200
+        assert response.id == control.id

--- a/tests/issuing/issuing_client_test.py
+++ b/tests/issuing/issuing_client_test.py
@@ -3,6 +3,7 @@ import pytest
 from checkout_sdk.issuing.cardholders import CardholderRequest
 from checkout_sdk.issuing.cards import PhysicalCardRequest, PasswordEnrollmentRequest, UpdateThreeDsEnrollmentRequest, \
     CardCredentialsQuery, RevokeRequest, SuspendRequest
+from checkout_sdk.issuing.controls import MccControlRequest, CardControlsQuery, UpdateCardControlRequest
 from checkout_sdk.issuing.issuing_client import IssuingClient
 
 
@@ -60,3 +61,23 @@ class TestIssuingClient:
     def test_should_suspend_card(self, mocker, client: IssuingClient):
         mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
         assert client.suspend_card('card_id', SuspendRequest()) == 'response'
+
+    def test_should_create_control(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.post', return_value='response')
+        assert client.create_control(MccControlRequest()) == 'response'
+
+    def test_should_get_card_controls(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.get_card_controls(CardControlsQuery()) == 'response'
+
+    def test_should_get_card_control_details(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.get', return_value='response')
+        assert client.get_card_control_details('control_id') == 'response'
+
+    def test_should_update_card_control(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.put', return_value='response')
+        assert client.update_card_control('control_id', UpdateCardControlRequest()) == 'response'
+
+    def test_should_remove_control(self, mocker, client: IssuingClient):
+        mocker.patch('checkout_sdk.api_client.ApiClient.delete', return_value='response')
+        assert client.remove_control('control_id') == 'response'


### PR DESCRIPTION
### Changes
* Adds support for `create_control`
* Adds support for `get_card_controls`
* Adds support for `get_card_control_details`
* Adds support for `update_card_control`
* Adds support for `remove_control`

### Related PRs
#128 

### API Reference
https://api-reference.checkout.com/#tag/Card-controls