### PR TITLE
feat: add missing FORWARD scope to oauth_scopes.py

### DIFF
--- a/checkout_sdk/oauth_scopes.py
+++ b/checkout_sdk/oauth_scopes.py
@@ -51,3 +51,5 @@ class OAuthScopes(str, Enum):
     ISSUING_CONTROLS_WRITE = 'issuing:controls-write'
 
     PAYMENT_CONTEXTS = 'Payment Contexts'
+
+    FORWARD = 'forward'


### PR DESCRIPTION
This pull request adds a new OAuth scope to the `OAuthScopes` enum in `checkout_sdk/oauth_scopes.py`.

* [`checkout_sdk/oauth_scopes.py`](diffhunk://#diff-334464a74fa02005eb60f222093e6b4f0cfc8277eee087652c742ab854ff77e9R54-R55): Added the `FORWARD` scope to the `OAuthScopes` enum to support new functionality related to forwarding operations.