### PR TITLE
feat: enhance CheckoutApiException to include request_id and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,15 @@ def oauth():
 ## Exception handling
 
 All the API responses that do not fall in the 2** status codes will cause a `CheckoutApiException`. The exception encapsulates
-the `http_metadata` and a dictionary of `error_details`, if available.
+the `http_metadata`, `request_id`, `error_type`, and a list of `error_details`, if available.
 
 ```python
 try:
     checkout_api.customers.get("customer_id")
 except CheckoutApiException as err:
     http_status_code = err.http_metadata.status_code
+    request_id = err.request_id
+    error_type = err.error_type
     error_details = err.error_details
 ```
 

--- a/checkout_sdk/exception.py
+++ b/checkout_sdk/exception.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from checkout_sdk.authorization_type import AuthorizationType
 from checkout_sdk.utils import map_to_http_metadata
 
@@ -33,21 +35,27 @@ class CheckoutAuthorizationException(CheckoutException):
 
 class CheckoutApiException(CheckoutException):
     http_metadata: dict
+    request_id: str
     error_details: list
     error_type: str
 
     def __init__(self, response):
         self.http_metadata = map_to_http_metadata(response)
+        self.request_id = None
+        self.error_details = None
+        self.error_type = None
+
         if response.text:
             try:
                 payload = response.json()
+                self.request_id = payload.get('request_id')
                 self.error_details = payload.get('error_codes')
                 self.error_type = payload.get('error_type')
-            except ValueError:
-                self.error_details = None
-                self.error_type = None
-        else:
-            self.error_details = None
-            self.error_type = None
+            except (ValueError, KeyError, TypeError) as e:
+                logging.error("Failed to parse response JSON payload: %s", e)
+
+        if not self.request_id:
+            self.request_id = response.headers.get('Cko-Request-Id')
+
         super().__init__('The API response status code ({}) does not indicate success.'
                          .format(response.status_code))

--- a/tests/checkout_test_utils.py
+++ b/tests/checkout_test_utils.py
@@ -117,7 +117,7 @@ class VisaCard:
     name: str = 'Checkout Test'
     number: str = '4242424242424242'
     expiry_month: int = 6
-    expiry_year: int = 2025
+    expiry_year: int = 2030
     cvv: str = '100'
 
 

--- a/tests/payments/request_apm_payments_integration_test.py
+++ b/tests/payments/request_apm_payments_integration_test.py
@@ -223,7 +223,8 @@ def test_should_request_alipay_plus_payment(default_api):
     except CheckoutApiException as err:
         assert err.args[0] == 'The API response status code (422) does not indicate success.'
         assert err.error_type == 'invalid_request'
-        assert err.error_details[0] == 'reference_invalid'
+        assert err.error_details is not None and 'reference_invalid' in err.error_details
+        assert err.request_id is not None
 
 
 def test_should_make_przelewy24_payment(default_api):


### PR DESCRIPTION
This pull request enhances the `CheckoutApiException` class to provide more detailed error information, including the `request_id` and `error_type` fields. It also updates the test suite to validate these new additions and ensures better error handling in various scenarios.

### Enhancements to Exception Handling:
* Updated the `CheckoutApiException` class to include `request_id` and `error_type` fields, populated from the response body or headers as a fallback. Improved error handling for missing or malformed JSON responses. (`checkout_sdk/exception.py`)
* Updated the documentation to reflect the new `request_id` and `error_type` attributes in the exception handling example. (`README.md`)

### Test Suite Updates:
* Modified existing tests and added new ones to validate the presence of `request_id` and proper fallback mechanisms when it is missing in the response body. (`tests/exception_test.py`) [[1]](diffhunk://#diff-139a774cc68f90aa98181bf467f82b2a7cdac11e40772356a49b14626a4bea6dL69-R180) [[2]](diffhunk://#diff-139a774cc68f90aa98181bf467f82b2a7cdac11e40772356a49b14626a4bea6dL153-R224)
* Enhanced integration tests to assert the presence of `request_id` in error scenarios. (`tests/payments/request_apm_payments_integration_test.py`)

### Miscellaneous:
* Updated the `expiry_year` for `VisaCard` test data to extend its validity. (`tests/checkout_test_utils.py`)