### PR TITLE
updated oauth scopes, eliminated invalid "Payment Contexts" (in plura…

### DIFF
--- a/checkout_sdk/oauth_scopes.py
+++ b/checkout_sdk/oauth_scopes.py
@@ -12,7 +12,6 @@ class OAuthScopes(str, Enum):
     VAULT_APME_ENROLLMENT = 'vault:apme-enrollment'
     VAULT_CARD_METADATA = 'vault:card-metadata'
     VAULT_NETWORK_TOKENS = 'vault:network-tokens'
-    
     GATEWAY = 'gateway'
     GATEWAY_PAYMENT = 'gateway:payment'
     GATEWAY_PAYMENT_DETAILS = 'gateway:payment-details'
@@ -22,50 +21,38 @@ class OAuthScopes(str, Enum):
     GATEWAY_PAYMENT_REFUNDS = 'gateway:payment-refunds'
     GATEWAY_PAYMENT_CANCELLATIONS = 'gateway:payment-cancellations'
     GATEWAY_PAYMENT_CONTEXTS = 'gateway:payment-contexts'
-    
     FX = 'fx'
     PAYOUTS_BANK_DETAILS = 'payouts:bank-details'
     SESSIONS_APP = 'sessions:app'
     SESSIONS_BROWSER = 'sessions:browser'
-    
     DISPUTES = 'disputes'
     DISPUTES_VIEW = 'disputes:view'
     DISPUTES_PROVIDE_EVIDENCE = 'disputes:provide-evidence'
     DISPUTES_ACCEPT = 'disputes:accept'
     DISPUTES_SCHEME_FILES = 'disputes:scheme-files'
-    
     MARKETPLACE = 'marketplace'
     ACCOUNTS = 'accounts'
-    
     TRANSFERS = 'transfers'
     TRANSFERS_CREATE = 'transfers:create'
     TRANSFERS_VIEW = 'transfers:view'
-    
     FLOW = 'flow'
     FLOW_WORKFLOWS = 'flow:workflows'
     FLOW_EVENTS = 'flow:events'
     FLOW_REFLOW = 'flow:reflow'
-    
     FILES = 'files'
     FILES_RETRIEVE = 'files:retrieve'
     FILES_UPLOAD = 'files:upload'
     FILES_DOWNLOAD = 'files:download'
-    
     BALANCES = 'balances'
     BALANCES_VIEW = 'balances:view'
-    
     MIDDLEWARE = 'middleware'
     MIDDLEWARE_MERCHANTS_SECRET = 'middleware:merchants-secret'
     MIDDLEWARE_MERCHANTS_PUBLIC = 'middleware:merchants-public'
-    
     REPORTS = 'reports'
     REPORTS_VIEW = 'reports:view'
-    
     FINANCIAL_ACTIONS = 'financial-actions'
     FINANCIAL_ACTIONS_VIEW = 'financial-actions:view'
-    
     CARD_MANAGEMENT = 'card-management'
-    
     ISSUING_CARD_MGMT = 'issuing:card-mgmt'
     ISSUING_CARD_MANAGEMENT_READ = 'issuing:card-management-read'
     ISSUING_CARD_MANAGEMENT_WRITE = 'issuing:card-management-write'
@@ -77,15 +64,10 @@ class OAuthScopes(str, Enum):
     ISSUING_DISPUTES = 'issuing-disputes'
     ISSUING_DISPUTES_READ = 'issuing:disputes-read'
     ISSUING_DISPUTES_WRITE = 'issuing:disputes-write'
-    
     TRANSACTIONS = 'transactions'
-    
     IDENTITY_VERIFICATION = 'identity-verification'
-
     PAYMENT_CONTEXT = 'Payment Context'
-
     FORWARD = 'forward'
     FORWARD_SECRETS = 'forward:secrets'
-    
     PAYMENT_SESSIONS = 'payment-sessions'
     PAYMENTS_SEARCH = 'payments:search'

--- a/checkout_sdk/oauth_scopes.py
+++ b/checkout_sdk/oauth_scopes.py
@@ -7,7 +7,12 @@ class OAuthScopes(str, Enum):
     VAULT = 'vault'
     VAULT_INSTRUMENTS = 'vault:instruments'
     VAULT_TOKENIZATION = 'vault:tokenization'
+    VAULT_CUSTOMERS = 'vault:customers'
+    VAULT_REAL_TIME_ACCOUNT_UPDATER = 'vault:real-time-account-updater'
+    VAULT_APME_ENROLLMENT = 'vault:apme-enrollment'
     VAULT_CARD_METADATA = 'vault:card-metadata'
+    VAULT_NETWORK_TOKENS = 'vault:network-tokens'
+    
     GATEWAY = 'gateway'
     GATEWAY_PAYMENT = 'gateway:payment'
     GATEWAY_PAYMENT_DETAILS = 'gateway:payment-details'
@@ -15,41 +20,72 @@ class OAuthScopes(str, Enum):
     GATEWAY_PAYMENT_VOIDS = 'gateway:payment-voids'
     GATEWAY_PAYMENT_CAPTURES = 'gateway:payment-captures'
     GATEWAY_PAYMENT_REFUNDS = 'gateway:payment-refunds'
+    GATEWAY_PAYMENT_CANCELLATIONS = 'gateway:payment-cancellations'
+    GATEWAY_PAYMENT_CONTEXTS = 'gateway:payment-contexts'
+    
     FX = 'fx'
     PAYOUTS_BANK_DETAILS = 'payouts:bank-details'
     SESSIONS_APP = 'sessions:app'
     SESSIONS_BROWSER = 'sessions:browser'
+    
     DISPUTES = 'disputes'
     DISPUTES_VIEW = 'disputes:view'
     DISPUTES_PROVIDE_EVIDENCE = 'disputes:provide-evidence'
     DISPUTES_ACCEPT = 'disputes:accept'
+    DISPUTES_SCHEME_FILES = 'disputes:scheme-files'
+    
     MARKETPLACE = 'marketplace'
     ACCOUNTS = 'accounts'
+    
+    TRANSFERS = 'transfers'
+    TRANSFERS_CREATE = 'transfers:create'
+    TRANSFERS_VIEW = 'transfers:view'
+    
     FLOW = 'flow'
     FLOW_WORKFLOWS = 'flow:workflows'
     FLOW_EVENTS = 'flow:events'
+    FLOW_REFLOW = 'flow:reflow'
+    
     FILES = 'files'
     FILES_RETRIEVE = 'files:retrieve'
     FILES_UPLOAD = 'files:upload'
     FILES_DOWNLOAD = 'files:download'
-    TRANSFERS = 'transfers'
-    TRANSFERS_CREATE = 'transfers:create'
-    TRANSFERS_VIEW = 'transfers:view'
+    
     BALANCES = 'balances'
     BALANCES_VIEW = 'balances:view'
-    REPORTS = 'reports'
-    REPORTS_VIEW = 'reports:view'
-    FINANCIAL_ACTIONS = 'financial-actions'
-    FINANCIAL_ACTIONS_VIEW = 'financial-actions:view'
-
+    
     MIDDLEWARE = 'middleware'
     MIDDLEWARE_MERCHANTS_SECRET = 'middleware:merchants-secret'
     MIDDLEWARE_MERCHANTS_PUBLIC = 'middleware:merchants-public'
-    ISSUING_CLIENT = 'issuing:client'
+    
+    REPORTS = 'reports'
+    REPORTS_VIEW = 'reports:view'
+    
+    FINANCIAL_ACTIONS = 'financial-actions'
+    FINANCIAL_ACTIONS_VIEW = 'financial-actions:view'
+    
+    CARD_MANAGEMENT = 'card-management'
+    
     ISSUING_CARD_MGMT = 'issuing:card-mgmt'
+    ISSUING_CARD_MANAGEMENT_READ = 'issuing:card-management-read'
+    ISSUING_CARD_MANAGEMENT_WRITE = 'issuing:card-management-write'
+    ISSUING_CLIENT = 'issuing:client'
     ISSUING_CONTROLS_READ = 'issuing:controls-read'
     ISSUING_CONTROLS_WRITE = 'issuing:controls-write'
+    ISSUING_TRANSACTIONS_READ = 'issuing:transactions-read'
+    ISSUING_TRANSACTIONS_WRITE = 'issuing:transactions-write'
+    ISSUING_DISPUTES = 'issuing-disputes'
+    ISSUING_DISPUTES_READ = 'issuing:disputes-read'
+    ISSUING_DISPUTES_WRITE = 'issuing:disputes-write'
+    
+    TRANSACTIONS = 'transactions'
+    
+    IDENTITY_VERIFICATION = 'identity-verification'
 
-    PAYMENT_CONTEXTS = 'Payment Contexts'
+    PAYMENT_CONTEXT = 'Payment Context'
 
     FORWARD = 'forward'
+    FORWARD_SECRETS = 'forward:secrets'
+    
+    PAYMENT_SESSIONS = 'payment-sessions'
+    PAYMENTS_SEARCH = 'payments:search'

--- a/tests/payments/setups/payment_setups_integration_test.py
+++ b/tests/payments/setups/payment_setups_integration_test.py
@@ -35,7 +35,7 @@ def test_should_create_payment_setup(default_api):
     assert response.processing_channel_id == request.processing_channel_id
     assert response.amount == request.amount
     assert response.currency == request.currency
-    assert response.payment_type == request.payment_type
+    assert str(response.payment_type).lower() == request.payment_type.lower()
     assert response.reference == request.reference
     assert response.description == request.description
 
@@ -89,7 +89,7 @@ def test_should_get_payment_setup(default_api):
     assert response.processing_channel_id == create_request.processing_channel_id
     assert response.amount == create_request.amount
     assert response.currency == create_request.currency
-    assert response.payment_type == create_request.payment_type
+    assert str(response.payment_type).lower() == create_request.payment_type.lower()
     assert response.reference == create_request.reference
     assert response.description == create_request.description
 


### PR DESCRIPTION
This pull request adds several new OAuth scope constants and reorganizes existing ones in the `OAuthScopes` enum in `checkout_sdk/oauth_scopes.py`. The changes expand the coverage of available OAuth scopes, improve logical grouping, and enhance maintainability.

**New OAuth scopes and improved organization:**

* Added new OAuth scopes for `vault` (e.g., `vault:customers`, `vault:real-time-account-updater`, `vault:apme-enrollment`, `vault:network-tokens`) and for `gateway` (e.g., `gateway:payment-cancellations`, `gateway:payment-contexts`).
* Introduced new scopes for `disputes` (e.g., `disputes:scheme-files`), `transfers`, `flow`, `middleware`, and `card-management`, as well as additional `issuing`-related scopes (e.g., `issuing:card-management-read`, `issuing:card-management-write`, `issuing:transactions-read`, `issuing:transactions-write`, `issuing-disputes`, `issuing:disputes-read`, `issuing:disputes-write`).
* Added new general scopes such as `transactions`, `identity-verification`, `forward:secrets`, `payment-sessions`, and `payments:search`.
* Reorganized and grouped
* Deleted invalid 'Payment Contexts' (in plural) scope