### PR TITLE
Release 3.6.1

### DIFF
--- a/checkout_sdk/properties.py
+++ b/checkout_sdk/properties.py
@@ -1,1 +1,1 @@
-VERSION = "3.6.0"
+VERSION = "3.6.1"


### PR DESCRIPTION
This release makes a small update to the project's dependencies by adding the `Deprecated` package to the `install_requires` list in `setup.py`. This ensures that the package is installed alongside the other dependencies.

- Added `Deprecated >= 1.2.14` to the `install_requires` section in `setup.py` to manage deprecated functionality.