### PR TITLE
fix: route forward and identity clients to dedicated base URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ htmlcov
 .cursor/rules/
 .cursor/skills/
 .vscode/settings.json
+
+.claude/
+CLAUDE.md

--- a/checkout_sdk/checkout_api.py
+++ b/checkout_sdk/checkout_api.py
@@ -59,10 +59,20 @@ def _balances_api_client(configuration: CheckoutConfiguration) -> ApiClient:
     return ApiClient(configuration, configuration.environment.balances_uri)
 
 
+def _forward_api_client(configuration: CheckoutConfiguration) -> ApiClient:
+    return ApiClient(configuration, configuration.environment.forward_uri)
+
+
+def _identity_api_client(configuration: CheckoutConfiguration) -> ApiClient:
+    return ApiClient(configuration, configuration.environment.identity_uri)
+
+
 class CheckoutApi(CheckoutApmApi):
 
     def __init__(self, configuration: CheckoutConfiguration):
         base_api_client = _base_api_client(configuration)
+        forward_api_client = _forward_api_client(configuration)
+        identity_api_client = _identity_api_client(configuration)
         super().__init__(base_api_client, configuration)
         self.tokens = TokensClient(api_client=base_api_client, configuration=configuration)
         self.customers = CustomersClient(api_client=base_api_client, configuration=configuration)
@@ -87,16 +97,17 @@ class CheckoutApi(CheckoutApmApi):
         self.issuing = IssuingClient(api_client=base_api_client, configuration=configuration)
         self.contexts = PaymentContextsClient(api_client=base_api_client, configuration=configuration)
         self.payment_sessions = PaymentSessionsClient(api_client=base_api_client, configuration=configuration)
-        self.forward = ForwardClient(api_client=base_api_client, configuration=configuration)
+        self.forward = ForwardClient(api_client=forward_api_client, configuration=configuration)
         self.setups = PaymentSetupsClient(api_client=base_api_client, configuration=configuration)
         self.agentic_commerce = AgenticCommerceClient(api_client=base_api_client, configuration=configuration)
         self.apple_pay = ApplePayClient(api_client=base_api_client, configuration=configuration)
         self.google_pay = GooglePayClient(api_client=base_api_client, configuration=configuration)
         self.standalone_account_updater = StandaloneAccountUpdaterClient(api_client=base_api_client,
                                                                          configuration=configuration)
-        self.aml_screening = AmlScreeningClient(api_client=base_api_client, configuration=configuration)
-        self.face_authentication = FaceAuthenticationClient(api_client=base_api_client, configuration=configuration)
-        self.id_document_verification = IdDocumentVerificationClient(api_client=base_api_client,
+        self.aml_screening = AmlScreeningClient(api_client=identity_api_client, configuration=configuration)
+        self.face_authentication = FaceAuthenticationClient(api_client=identity_api_client, configuration=configuration)
+        self.id_document_verification = IdDocumentVerificationClient(api_client=identity_api_client,
                                                                      configuration=configuration)
-        self.applicants = ApplicantsClient(api_client=base_api_client, configuration=configuration)
-        self.identity_verification = IdentityVerificationClient(api_client=base_api_client, configuration=configuration)
+        self.applicants = ApplicantsClient(api_client=identity_api_client, configuration=configuration)
+        self.identity_verification = IdentityVerificationClient(api_client=identity_api_client,
+                                                                configuration=configuration)

--- a/checkout_sdk/environment.py
+++ b/checkout_sdk/environment.py
@@ -8,12 +8,16 @@ class Environment:
                  files_uri,
                  transfers_uri,
                  balances_uri,
+                 forward_uri,
+                 identity_uri,
                  is_sandbox):
         self.base_uri = base_uri
         self.authorization_uri = authorization_uri
         self.files_uri = files_uri
         self.transfers_uri = transfers_uri
         self.balances_uri = balances_uri
+        self.forward_uri = forward_uri
+        self.identity_uri = identity_uri
         self.is_sandbox = is_sandbox
 
     @staticmethod
@@ -23,6 +27,8 @@ class Environment:
                            files_uri='https://files.sandbox.checkout.com/',
                            transfers_uri='https://transfers.sandbox.checkout.com/',
                            balances_uri='https://balances.sandbox.checkout.com/',
+                           forward_uri='https://forward.sandbox.checkout.com/',
+                           identity_uri='https://identity-verification.sandbox.checkout.com/',
                            is_sandbox=True)
 
     @staticmethod
@@ -32,4 +38,6 @@ class Environment:
                            files_uri='https://files.checkout.com/',
                            transfers_uri='https://transfers.checkout.com/',
                            balances_uri='https://balances.checkout.com/',
+                           forward_uri='https://forward.checkout.com/',
+                           identity_uri='https://identity-verification.checkout.com/',
                            is_sandbox=False)

--- a/checkout_sdk/environment_subdomain.py
+++ b/checkout_sdk/environment_subdomain.py
@@ -25,7 +25,7 @@ class EnvironmentSubdomain:
         """
         new_environment = original_url
 
-        regex = r'^[a-z0-9]+(-[a-z0-9]+)*$'
+        regex = r'^(?:pl-)?[a-z0-9]+$'
         if re.match(regex, subdomain):
             url_parts = urlparse(original_url)
             if url_parts.port:

--- a/checkout_sdk/environment_subdomain.py
+++ b/checkout_sdk/environment_subdomain.py
@@ -25,7 +25,7 @@ class EnvironmentSubdomain:
         """
         new_environment = original_url
 
-        regex = r'^[0-9a-z]+$'
+        regex = r'^[a-z0-9]+(-[a-z0-9]+)*$'
         if re.match(regex, subdomain):
             url_parts = urlparse(original_url)
             if url_parts.port:

--- a/tests/checkout_configuration_test.py
+++ b/tests/checkout_configuration_test.py
@@ -31,6 +31,20 @@ def test_should_create_configuration():
     assert configuration.environment_subdomain is None
 
 
+def test_environment_sandbox_urls():
+    env = Environment.sandbox()
+    assert env.base_uri == "https://api.sandbox.checkout.com/"
+    assert env.forward_uri == "https://forward.sandbox.checkout.com/"
+    assert env.identity_uri == "https://identity-verification.sandbox.checkout.com/"
+
+
+def test_environment_production_urls():
+    env = Environment.production()
+    assert env.base_uri == "https://api.checkout.com/"
+    assert env.forward_uri == "https://forward.checkout.com/"
+    assert env.identity_uri == "https://identity-verification.checkout.com/"
+
+
 @pytest.mark.parametrize(
     "subdomain, expected_url",
     [
@@ -38,7 +52,9 @@ def test_should_create_configuration():
         ("ab", "https://ab.api.sandbox.checkout.com/"),
         ("abc", "https://abc.api.sandbox.checkout.com/"),
         ("abc1", "https://abc1.api.sandbox.checkout.com/"),
-        ("12345domain", "https://12345domain.api.sandbox.checkout.com/")
+        ("12345domain", "https://12345domain.api.sandbox.checkout.com/"),
+        ("test-123", "https://test-123.api.sandbox.checkout.com/"),
+        ("pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/")
     ]
 )
 def test_should_create_configuration_with_subdomain(subdomain, expected_url):
@@ -74,7 +90,10 @@ def test_should_create_configuration_with_subdomain(subdomain, expected_url):
         ("   ", "https://api.sandbox.checkout.com/"),
         (" - ", "https://api.sandbox.checkout.com/"),
         ("a b", "https://api.sandbox.checkout.com/"),
-        ("ab c1.", "https://api.sandbox.checkout.com/")
+        ("ab c1.", "https://api.sandbox.checkout.com/"),
+        ("foo-", "https://api.sandbox.checkout.com/"),
+        ("-foo", "https://api.sandbox.checkout.com/"),
+        ("FooBar", "https://api.sandbox.checkout.com/")
     ]
 )
 def test_should_create_configuration_with_bad_subdomain(subdomain, expected_url):

--- a/tests/checkout_configuration_test.py
+++ b/tests/checkout_configuration_test.py
@@ -53,7 +53,7 @@ def test_environment_production_urls():
         ("abc", "https://abc.api.sandbox.checkout.com/"),
         ("abc1", "https://abc1.api.sandbox.checkout.com/"),
         ("12345domain", "https://12345domain.api.sandbox.checkout.com/"),
-        ("test-123", "https://test-123.api.sandbox.checkout.com/"),
+        ("pl-vkuhvk4v", "https://pl-vkuhvk4v.api.sandbox.checkout.com/"),
         ("pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/")
     ]
 )
@@ -93,7 +93,10 @@ def test_should_create_configuration_with_subdomain(subdomain, expected_url):
         ("ab c1.", "https://api.sandbox.checkout.com/"),
         ("foo-", "https://api.sandbox.checkout.com/"),
         ("-foo", "https://api.sandbox.checkout.com/"),
-        ("FooBar", "https://api.sandbox.checkout.com/")
+        ("FooBar", "https://api.sandbox.checkout.com/"),
+        ("test-123", "https://api.sandbox.checkout.com/"),
+        ("foo-bar", "https://api.sandbox.checkout.com/"),
+        ("pl-", "https://api.sandbox.checkout.com/")
     ]
 )
 def test_should_create_configuration_with_bad_subdomain(subdomain, expected_url):


### PR DESCRIPTION
## Summary

The forward service and the identity-verification services (AML screening, face authentication, ID document verification, applicants, identity verification) live on their own hosts in the swagger spec, not under `api.checkout.com`. This PR adds dedicated URIs for both and routes the corresponding clients through them. It also tightens the subdomain validation regex to match the AWS PrivateLink prefix format documented at https://www.checkout.com/docs/developer-resources/api/private-connections/aws-privatelink — `^(?:pl-)?[a-z0-9]+$` (alphanumeric, optionally prefixed by the literal `pl-`).

## Changes

- `checkout_sdk/environment.py` — adds `forward_uri` and `identity_uri` parameters to the `Environment` constructor; populates sandbox/production values
- `checkout_sdk/checkout_api.py` — adds `_forward_api_client` and `_identity_api_client` factories; routes `forward` to forward URI; routes `aml_screening`, `face_authentication`, `id_document_verification`, `applicants`, `identity_verification` to a single cached identity `ApiClient`
- `checkout_sdk/environment_subdomain.py` — tightens regex to `^(?:pl-)?[a-z0-9]+$`
- `tests/checkout_configuration_test.py` — updates subdomain corpus: removes `test-123` from accepted, adds `pl-vkuhvk4v` (docs example), adds `test-123`/`foo-bar`/`pl-` to rejected; adds `test_environment_sandbox_urls` / `test_environment_production_urls`

## API Reference

- `https://forward.checkout.com` / `https://forward.sandbox.checkout.com` — forward service (`POST /forward`, `GET /forward/{id}`, `POST /forward/secrets`, `GET|POST|DELETE /forward/secrets/{name}`)
- `https://identity-verification.checkout.com` / `https://identity-verification.sandbox.checkout.com` — identity services (`/applicants`, `/identity-verifications`, `/aml-verifications`, `/face-authentications`, `/id-document-verifications`)
- `https://pl-{prefix}.api.{sandbox.,}checkout.com` — AWS PrivateLink subdomain format

## Breaking changes

- `Environment.__init__` signature adds two new positional parameters (`forward_uri`, `identity_uri`). Anyone constructing `Environment` directly (rather than via the `Environment.sandbox()` / `Environment.production()` factories) must update.
- The subdomain regex is now stricter: arbitrary hyphenated subdomains like `test-123` or `foo-bar-baz` are rejected. Only plain alphanumeric or the literal PrivateLink form (`pl-{prefix}`) are accepted.

## README

Not affected.