### PR TITLE
feat: add InstrumentDocumentType with bank_statement

### DIFF
--- a/checkout_sdk/common/enums.py
+++ b/checkout_sdk/common/enums.py
@@ -550,12 +550,21 @@ class AccountHolderIdentificationType(str, Enum):
 
 
 class DocumentType(str, Enum):
+    """Identity documents. The document type accepted when verifying a bank account is a
+    separate enum, InstrumentDocumentType, because the API keeps the two apart."""
     PASSPORT = 'passport'
     NATIONAL_IDENTITY_CARD = 'national_identity_card'
     DRIVING_LICENSE = 'driving_license'
     CITIZEN_CARD = 'citizen_card'
     RESIDENCE_PERMIT = 'residence_permit'
     ELECTORAL_ID = 'electoral_id'
+
+
+class InstrumentDocumentType(str, Enum):
+    """The document type accepted by the legal document that verifies a bank account when
+    creating a payment instrument. The API accepts only bank_statement here, which is also the
+    default, and rejects the identity document types in DocumentType."""
+    BANK_STATEMENT = 'bank_statement'
 
 
 class AccountChangeIndicatorType(str, Enum):

--- a/tests/accounts/instrument_document_type_test.py
+++ b/tests/accounts/instrument_document_type_test.py
@@ -1,0 +1,19 @@
+from checkout_sdk.common.enums import DocumentType, InstrumentDocumentType
+
+
+def test_should_expose_bank_statement_for_instrument_documents():
+    assert InstrumentDocumentType.BANK_STATEMENT == 'bank_statement'
+    assert InstrumentDocumentType.BANK_STATEMENT.value == 'bank_statement'
+
+
+def test_should_be_the_only_accepted_instrument_document_type():
+    # The spec declares a single-value enum here, so anything else is a caller error rather
+    # than a value we forgot to add.
+    assert [d.value for d in InstrumentDocumentType] == ['bank_statement']
+
+
+def test_should_keep_bank_statement_out_of_the_identity_document_type():
+    # bank_statement belongs to the instrument document enum, not the identity one. The API
+    # keeps them separate, and this is what stops the two being merged the next time someone
+    # reports the value as missing from DocumentType.
+    assert 'bank_statement' not in [d.value for d in DocumentType]


### PR DESCRIPTION
## What

Adds `InstrumentDocumentType` with the single value `bank_statement`, the document type for the bank account behind a platforms payment instrument.

Reported internally: the value is documented in the API reference but missing from the SDK, and it is blocking a merchant. Verified against the spec, where that document type is a single-value enum whose only accepted value (and default) is `bank_statement`.

## Why a separate type instead of adding the value to the existing document type

The existing document type lists identity documents (passport, national identity card, driving license) and is used for entity onboarding. The API models the bank account document type as its own enum. Adding `bank_statement` alongside the identity values would offer it in every place the API rejects it, and would equally suggest the identity values are accepted on an instrument document, where they are not.

## Tests

One of the tests asserts `bank_statement` is **not** in the identity document type. That is deliberate: it is what stops the two being merged the next time someone reports the value as missing from the identity enum.

## Not breaking

Purely additive. No existing constant, field or signature changes.

Refs INT-1691.