### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/checkout_sdk/payments/payments.py
+++ b/checkout_sdk/payments/payments.py
@@ -883,6 +883,8 @@ class RefundRequest:
 
 # Voids
 class VoidRequest:
+    # If not specified, the full payment amount is voided (min 0, max 9999999999)
+    amount: int
     reference: str
     metadata: dict
 

--- a/tests/payments/void_request_serialization_test.py
+++ b/tests/payments/void_request_serialization_test.py
@@ -1,0 +1,30 @@
+import json
+
+from checkout_sdk.json_serializer import JsonSerializer
+from checkout_sdk.payments.payments import VoidRequest
+
+
+def _serialize(obj):
+    return json.loads(json.dumps(obj, cls=JsonSerializer))
+
+
+class TestVoidRequestSerialization:
+
+    def test_void_request_serializes_amount_when_set(self):
+        request = VoidRequest()
+        request.amount = 500
+        request.reference = 'partial-void-reference'
+
+        assert _serialize(request) == {
+            'amount': 500,
+            'reference': 'partial-void-reference',
+        }
+
+    def test_void_request_omits_amount_when_not_set(self):
+        request = VoidRequest()
+        request.reference = 'full-void-reference'
+
+        serialized = _serialize(request)
+
+        assert 'amount' not in serialized
+        assert serialized == {'reference': 'full-void-reference'}


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.