### PR TITLE
Release 4.0.0

### DIFF
--- a/checkout_sdk/properties.py
+++ b/checkout_sdk/properties.py
@@ -1,1 +1,1 @@
-VERSION = "3.13.0"
+VERSION = "4.0.0"


### PR DESCRIPTION
- The merchant-specific subdomain (environment_subdomain) is now required. Set it, or call the deprecated use_legacy_domain() to keep using the shared checkout.com hosts (#226)
- An invalid subdomain now raises instead of being silently ignored (#226)
- Add optional amount to VoidRequest to support partial voids (#229)
- Add the ISV (SaaS seller) payout schedule fields balance_minimum, carry_forward_enabled and payment_instrument_id (#230)